### PR TITLE
Add API version display and git commit tracking

### DIFF
--- a/build/build-pre.js
+++ b/build/build-pre.js
@@ -1,8 +1,16 @@
 const path = require('path');
 const fs = require('fs');
+const { execSync } = require('child_process');
 const appVersion = require('../package.json').version;
 const today = new Date();
 const versionFilePath = path.join(__dirname + '/../src/environments/version.ts');
+
+let gitCommit = 'unknown';
+try {
+  gitCommit = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (e) {
+  console.log('Warning: could not determine git commit hash');
+}
 
 function dateFormat (date, fstr, utc) {
     utc = utc ? 'getUTC' : 'get';
@@ -23,7 +31,7 @@ function dateFormat (date, fstr, utc) {
 }
 
 const build = dateFormat(today, '%y.%m.%d-%H%M');
-const src = `export const APP_VERSION = {version: '${appVersion}', build: '${build}', date: '${today.toISOString()}'};`;
+const src = `export const APP_VERSION = {version: '${appVersion}', build: '${build}', date: '${today.toISOString()}', commit: '${gitCommit}'};`;
 fs.writeFile(versionFilePath, src, { flat: 'w' }, function (err) {
     if (err) {
         return console.log(err);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,7 +25,7 @@
             </div>
 
             <div style="position:absolute;bottom: 0; right: 0;">
-                <small class="mr-1"><sup>v{{version.build}}</sup></small>
+                <small class="mr-1"><sup>API: {{apiVersion || '...'}} / Web: {{version.version}} ({{version.commit}})</sup></small>
             </div>
         </footer>
         <!-- End of Footer -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,17 @@ import { APP_VERSION } from '@env/version';
 import { Title } from '@angular/platform-browser';
 import { filter, map } from "rxjs/operators";
 import { AppInsightsService } from '@app/shared/services/app-insights.service';
+import { Apollo } from 'apollo-angular';
+import gql from 'graphql-tag';
+
+const BUILD_INFO_QUERY = gql`
+  query {
+    buildInfo {
+      version
+      commit
+    }
+  }
+`;
 
 @Component({
   selector: 'app-root',
@@ -17,6 +28,7 @@ import { AppInsightsService } from '@app/shared/services/app-insights.service';
 export class AppComponent {
   private actionSub: Subscription;
   version = APP_VERSION;
+  apiVersion = '';
   constructor(
     private toastr: ToastrService,
     private store: Store,
@@ -24,7 +36,8 @@ export class AppComponent {
     private titleService: Title,
     private router: Router,
     private activatedRoute: ActivatedRoute,
-    private appInsights: AppInsightsService
+    private appInsights: AppInsightsService,
+    private apollo: Apollo
   ) {
     titleService.setTitle("TaDa");
 
@@ -52,6 +65,15 @@ export class AppComponent {
 
   ngOnInit() {
     this.actionSub = this.actions.pipe(ofAction(RouterNavigation)).subscribe(({ event }) => this.handleAction(event));
+    this.apollo.query<any>({ query: BUILD_INFO_QUERY }).subscribe(
+      ({ data }) => {
+        if (data && data.buildInfo) {
+          const info = data.buildInfo;
+          this.apiVersion = `${info.version} (${info.commit})`;
+        }
+      },
+      () => {}
+    );
   }
 
   handleAction(action) {

--- a/src/environments/version.ts
+++ b/src/environments/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = {version: '1.0.2', build: '25.12.11-1153', date: '2025-12-11T11:53:43.227Z'};
+export const APP_VERSION = {version: '1.0.2', build: '26.04.09-1133', date: '2026-04-09T11:33:26.154Z', commit: 'e50b71f'};


### PR DESCRIPTION
## Summary
This PR adds the ability to fetch and display the API version alongside the web application version in the footer. It also enhances the build process to capture the current git commit hash for better version tracking.

## Key Changes
- **AppComponent**: Added Apollo GraphQL integration to query build information from the API
  - New `apiVersion` property to store the fetched API version and commit hash
  - GraphQL query `BUILD_INFO_QUERY` to retrieve `buildInfo.version` and `buildInfo.commit` from the backend
  - Query is executed in `ngOnInit()` with error handling
  
- **Build Process**: Enhanced `build-pre.js` to capture git commit information
  - Added git commit hash retrieval using `git rev-parse --short HEAD`
  - Graceful fallback to 'unknown' if git command fails
  - Commit hash is now included in the `APP_VERSION` export
  
- **Footer Display**: Updated version information display in `app.component.html`
  - Changed from showing only build number to displaying both API and Web versions
  - Format: `API: {version} ({commit}) / Web: {version} ({commit})`
  - Shows loading indicator ('...') while API version is being fetched

## Implementation Details
- The Apollo GraphQL client is injected into AppComponent to enable API communication
- The build script gracefully handles cases where git is unavailable (e.g., in CI/CD environments without git history)
- API version fetch errors are silently handled to prevent breaking the application if the backend endpoint is unavailable

https://claude.ai/code/session_01TrGEAzBHfdgSmoWzsiaP2t