### PR TITLE
Add GitHub Actions Docker publish workflow and GHCR deploy script

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,42 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/communitytechaid/techaid-dashboard
+          tags: |
+            type=raw,value=latest
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/scripts/deploy-from-ghcr.sh
+++ b/scripts/deploy-from-ghcr.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Checks for an updated Docker image in GHCR and redeploys the dokku app if a new image is found.
+# Intended to be run as a cron job (e.g. every minute via: * * * * * /path/to/deploy-from-ghcr.sh)
+set -euo pipefail
+
+IMAGE="ghcr.io/communitytechaid/techaid-dashboard:latest"
+APP="app"
+LOCKFILE="/tmp/techaid-dashboard-deploy.lock"
+
+# Prevent concurrent runs
+exec 9>"$LOCKFILE"
+flock -n 9 || exit 0
+
+# Record digest before pull
+OLD_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" 2>/dev/null || echo "")
+
+# Pull latest image from GHCR
+if ! docker pull "$IMAGE" > /dev/null 2>&1; then
+    echo "$(date): Failed to pull $IMAGE" >&2
+    exit 1
+fi
+
+# Record digest after pull
+NEW_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" 2>/dev/null || echo "")
+
+# Only redeploy if the image actually changed
+if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
+    echo "$(date): New image detected ($NEW_DIGEST), deploying to dokku app: $APP"
+    dokku git:from-image "$APP" "$IMAGE"
+fi


### PR DESCRIPTION
Replaces SSH-based Docker builds with a GitHub Actions workflow that builds and pushes the image to the public GitHub Container Registry (ghcr.io/communitytechaid/techaid-dashboard) using GITHUB_TOKEN — no additional secrets required.

Also adds scripts/deploy-from-ghcr.sh, a cron-friendly script for the dokku server that pulls the latest image every run and redeploys the 'app' application only when a new digest is detected.

https://claude.ai/code/session_012ZBSrvvea5Z23VxTn3N7bT