### PR TITLE
Fix API version display and restore build timestamps

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,7 +25,7 @@
             </div>
 
             <div style="position:absolute;bottom: 0; right: 0;">
-                <small class="mr-1"><sup>API: {{apiVersion || '...'}} / Web: {{version.version}} ({{version.commit}})</sup></small>
+                <small class="mr-1"><sup>API: {{apiVersion || '...'}} / Web: {{version.version}} ({{version.commit}}) {{version.build}}</sup></small>
             </div>
         </footer>
         <!-- End of Footer -->

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,6 +16,7 @@ const BUILD_INFO_QUERY = gql`
     buildInfo {
       version
       commit
+      time
     }
   }
 `;
@@ -69,10 +70,16 @@ export class AppComponent {
       ({ data }) => {
         if (data && data.buildInfo) {
           const info = data.buildInfo;
-          this.apiVersion = `${info.version} (${info.commit})`;
+          const time = info.time ? ' ' + info.time.replace(/T.*/, '') : '';
+          this.apiVersion = `${info.version} (${info.commit})${time}`;
+        } else {
+          this.apiVersion = 'unavailable';
         }
       },
-      () => {}
+      (err) => {
+        console.warn('Failed to fetch buildInfo', err);
+        this.apiVersion = 'unavailable';
+      }
     );
   }
 


### PR DESCRIPTION
- Add `time` field to buildInfo GraphQL query
- Show build timestamps for both API and Web in footer
- Handle query errors gracefully with 'unavailable' fallback
- Log errors to console for debugging blank API version

Footer now shows: API: 0.0.2-SNAPSHOT (9dee8b0) 2026-04-09 / Web: 1.0.2 (e50b71f) 26.04.09-1133

https://claude.ai/code/session_01TrGEAzBHfdgSmoWzsiaP2t