### PR TITLE
Fix deploy script to pass image digest to dokku git:from-image

### DIFF
--- a/scripts/deploy-from-ghcr.sh
+++ b/scripts/deploy-from-ghcr.sh
@@ -26,5 +26,5 @@ NEW_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" 2>/dev/
 # Only redeploy if the image actually changed
 if [ "$OLD_DIGEST" != "$NEW_DIGEST" ]; then
     echo "$(date): New image detected ($NEW_DIGEST), deploying to dokku app: $APP"
-    dokku git:from-image "$APP" "$IMAGE"
+    dokku git:from-image "$APP" "$NEW_DIGEST"
 fi


### PR DESCRIPTION
Passing :latest tag always gave dokku the same string, causing it to report "No changes detected" and skip the rebuild. Passing the full digest (ghcr.io/...@sha256:...) gives dokku a unique value on each new image, so it correctly triggers the deployment.

https://claude.ai/code/session_012ZBSrvvea5Z23VxTn3N7bT