### PR TITLE
Route GraphQL through nginx proxy instead of hardcoded URLs

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,7 +10,7 @@ import { ConfigParams } from '@app/state/config-params';
 export const environment: ConfigParams = {
   production: true,
   environment: 'production',
-  graphql_endpoint: 'https://api.communitytechaid.org.uk/graphql',
+  graphql_endpoint: '/api/graphql',
   version: APP_VERSION,
   auth_endpoint: 'https://api.communitytechaid.org.uk/auth/user',
   auth_audience: 'https://api.communitytechaid.org.uk',

--- a/src/environments/environment.uat.ts
+++ b/src/environments/environment.uat.ts
@@ -10,7 +10,7 @@ import { ConfigParams } from '@app/state/config-params';
 export const environment: ConfigParams = {
   production: false,
   environment: 'uat',
-  graphql_endpoint: 'https://api-testing.communitytechaid.org.uk/graphql',
+  graphql_endpoint: '/api/graphql',
   version: APP_VERSION,
   auth_endpoint: 'https://api-testing.communitytechaid.org.uk/auth/user',
   auth_audience: 'https://api.communitytechaid.org.uk',


### PR DESCRIPTION
The production and UAT environment configs had hardcoded API URLs (e.g. https://api.communitytechaid.org.uk/graphql), which bypasses the nginx proxy. This caused the UAT frontend to hit the production API, where buildInfo doesn't exist yet.

Change both to use /api/graphql so requests go through the nginx proxy, which routes to the correct backend via the API_HOST env var. The dev config already used this path.

https://claude.ai/code/session_01TrGEAzBHfdgSmoWzsiaP2t