### PR TITLE
Show version info on hover instead of inline text

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,8 +24,8 @@
                 </div>
             </div>
 
-            <div style="position:absolute;bottom: 0; right: 0;">
-                <small class="mr-1"><sup>API: {{apiVersion || '...'}} / Web: {{version.version}} ({{version.commit}}) {{version.build}}</sup></small>
+            <div style="position:absolute;bottom: 0; right: 0;" title="API: {{apiVersion || '...'}} / Web: {{version.version}} ({{version.commit}}) {{version.build}}">
+                <small class="mr-1"><sup>Version Info</sup></small>
             </div>
         </footer>
         <!-- End of Footer -->


### PR DESCRIPTION
The full version string (API + Web) is now ~100 chars and distracting for general users. Display 'Version Info' as the visible label with the full version string in a tooltip on hover.

https://claude.ai/code/session_01TrGEAzBHfdgSmoWzsiaP2t