### PR TITLE
Convert collectionDate to UTC ISO string before server update

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -919,6 +919,10 @@ export class DeviceRequestInfoComponent {
     if (data.deviceRequestNote.content == null){
       data.deviceRequestNote.content = ""
     }
+    // Convert collectionDate from datetime-local (local time) back to UTC ISO string for the server
+    if (data.collectionDate) {
+      data.collectionDate = new Date(data.collectionDate).toISOString();
+    }
     this.apollo
       .mutate({
         mutation: UPDATE_ENTITY,


### PR DESCRIPTION
## Summary
Fixed a timezone handling issue where the `collectionDate` field was not being properly converted to UTC ISO format before being sent to the server.

## Key Changes
- Added conversion logic to transform `collectionDate` from datetime-local (local browser time) to UTC ISO string format before sending the update mutation to the server
- The conversion uses `new Date(data.collectionDate).toISOString()` to ensure the date is properly formatted for server consumption

## Implementation Details
The fix addresses a common issue with HTML5 datetime-local inputs, which return dates in the user's local timezone. By converting to ISO string format before the GraphQL mutation, we ensure the server receives the date in a consistent UTC format, preventing timezone-related data inconsistencies.

https://claude.ai/code/session_01Tk1kuppcCE56BNeY7X4H7K