### PR TITLE
Rename isAdmin to canBulkEdit for clearer permission semantics

### DIFF
--- a/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
+++ b/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
@@ -276,7 +276,7 @@ export class KitIndexComponent {
   public user: User;
   @Select(UserState.user) user$: Observable<User>;
   isDonorParentAdmin = false;
-  isAdmin = false;
+  canBulkEdit = false;
   bulkMode = false;
   allPageSelected = false;
 
@@ -704,7 +704,7 @@ export class KitIndexComponent {
       this.user$.subscribe((user) => {
         this.user = user;
         this.isDonorParentAdmin = (user && user.authorities && user.authorities['read:donorParents']);
-        this.isAdmin = !!(user && user.authorities && user.authorities['app:admin']);
+        this.canBulkEdit = !!(user && user.authorities && user.authorities['app:bulkedit']);
         //console.log(this.isDonorParentAdmin);
         this.donorParentField.hideExpression = !this.isDonorParentAdmin;
         this.donorParentTypeField.hideExpression = !this.isDonorParentAdmin;

--- a/src/app/views/corewidgets/components/kit-index/kit-index.html
+++ b/src/app/views/corewidgets/components/kit-index/kit-index.html
@@ -11,7 +11,7 @@
                         <h6 class="m-0 font-weight-bold text-primary pr-1">Devices</h6>
                     </div>
                     <div class="d-flex align-items-center flex-wrap">
-                        <ng-container *ngIf="isAdmin">
+                        <ng-container *ngIf="canBulkEdit">
                             <div class="custom-control custom-switch mr-1 mb-1">
                                 <input type="checkbox" class="custom-control-input" id="bulkToggle"
                                     [checked]="bulkMode" (change)="toggleBulkMode()">


### PR DESCRIPTION
## Summary
Refactored the admin permission flag to use more semantically accurate naming that reflects its actual purpose: controlling bulk edit functionality rather than general admin access.

## Key Changes
- Renamed `isAdmin` property to `canBulkEdit` in the KitIndexComponent class
- Updated the permission check to validate the `'app:bulkedit'` authority instead of `'app:admin'`
- Updated the template to use the renamed property in the bulk mode toggle conditional

## Implementation Details
This change improves code clarity by using a property name that directly describes the permission's function (enabling bulk edit operations) rather than a generic admin flag. The permission authority was also updated from `'app:admin'` to `'app:bulkedit'` to align with a more granular permission model where bulk edit is a specific capability rather than a general admin privilege.

https://claude.ai/code/session_01NFnnekrwT6Vk3aV51VyKEt