### PR TITLE
Fix false success, improve error messages, add assignment confirmatio…

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
@@ -133,54 +133,92 @@
 <ng-template #assignDevicesModal let-c="close" let-d="dismiss">
   <div class="modal-header">
     <h4 class="modal-title">Assign Devices to Request #{{requestId}}</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')" [disabled]="isAssigning">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <div class="modal-body">
-    <div class="form-group">
-      <label for="assignDeviceInput"><strong>Device IDs</strong> (comma-separated)</label>
-      <textarea
-        id="assignDeviceInput"
-        class="form-control"
-        rows="3"
-        placeholder="e.g. 1234, 5678, 9012"
-        [value]="assignDeviceIds"
-        (input)="assignDeviceIds = $event.target['value']"
-        [disabled]="isAssigning">
-      </textarea>
-      <small class="form-text text-muted">Enter the IDs of devices to assign to this request, separated by commas.</small>
+
+    <!-- Phase 1: Input -->
+    <div *ngIf="!showAssignConfirmation && assignmentResults.length === 0">
+      <div class="form-group">
+        <label for="assignDeviceInput"><strong>Device IDs</strong> (comma-separated)</label>
+        <textarea
+          id="assignDeviceInput"
+          class="form-control"
+          rows="3"
+          placeholder="e.g. 1234, 5678, 9012"
+          [value]="assignDeviceIds"
+          (input)="assignDeviceIds = $event.target['value']">
+        </textarea>
+        <small class="form-text text-muted">Enter the IDs of devices to assign to this request, separated by commas.</small>
+      </div>
     </div>
 
-    <div *ngIf="assignmentResults.length > 0" class="mt-3">
-      <h6 class="font-weight-bold">Assignment Results:</h6>
-      <div class="border rounded p-2" style="max-height: 240px; overflow-y: auto; background: #f8f9fa; font-family: monospace; font-size: 0.85rem;">
-        <div *ngFor="let result of assignmentResults" class="mb-1"
-             [class.text-success]="result.status === 'success'"
-             [class.text-warning]="result.status === 'warning'"
-             [class.text-danger]="result.status === 'error'">
-          <i [class.fas]="true"
-             [class.fa-check-circle]="result.status === 'success'"
-             [class.fa-exclamation-triangle]="result.status === 'warning'"
-             [class.fa-times-circle]="result.status === 'error'"></i>
-          <strong> Device {{result.deviceId}}:</strong> {{result.message}}
+    <!-- Phase 2: Confirmation -->
+    <div *ngIf="showAssignConfirmation && !isAssigning">
+      <div class="alert alert-warning">
+        <i class="fas fa-exclamation-triangle mr-1"></i>
+        You are about to assign <strong>{{parsedDeviceIds.length}}</strong> device(s) to request <strong>#{{requestId}}</strong>. Click <strong>Confirm</strong> to continue.
+      </div>
+      <div class="border rounded p-2 bg-light" style="max-height: 180px; overflow-y: auto; font-family: monospace; font-size: 0.85rem;">
+        <div *ngFor="let id of parsedDeviceIds" class="mb-1">
+          <i class="fas fa-hdd text-secondary mr-1"></i> Device {{id}}
         </div>
       </div>
-      <small class="form-text text-muted mt-1">
-        {{assignmentResults.length}} device(s) processed
-      </small>
     </div>
+
+    <!-- Phase 3: Results (builds up during and after assignment) -->
+    <div *ngIf="isAssigning || assignmentResults.length > 0">
+      <div *ngIf="isAssigning" class="mb-2 text-muted small">
+        <i class="fas fa-spinner fa-spin mr-1"></i>
+        Assigning... ({{assignmentResults.length}} of {{parsedDeviceIds.length}} done)
+      </div>
+      <div *ngIf="assignmentResults.length > 0">
+        <h6 class="font-weight-bold">Assignment Results:</h6>
+        <div class="border rounded p-2" style="max-height: 240px; overflow-y: auto; background: #f8f9fa; font-family: monospace; font-size: 0.85rem;">
+          <div *ngFor="let result of assignmentResults" class="mb-1"
+               [class.text-success]="result.status === 'success'"
+               [class.text-warning]="result.status === 'warning'"
+               [class.text-danger]="result.status === 'error'">
+            <i [class.fas]="true"
+               [class.fa-check-circle]="result.status === 'success'"
+               [class.fa-exclamation-triangle]="result.status === 'warning'"
+               [class.fa-times-circle]="result.status === 'error'"></i>
+            <strong> Device {{result.deviceId}}:</strong> {{result.message}}
+          </div>
+        </div>
+        <small class="form-text text-muted mt-1">{{assignmentResults.length}} device(s) processed</small>
+      </div>
+    </div>
+
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-light btn-sm" (click)="c('Close click')">Close</button>
-    <button
-      type="button"
-      class="btn btn-success btn-sm"
-      [disabled]="isAssigning || !assignDeviceIds.trim()"
-      (click)="assignDevices()">
-      <i class="fas fa-spinner fa-spin" *ngIf="isAssigning"></i>
-      <i class="fas fa-link" *ngIf="!isAssigning"></i>
-      {{ isAssigning ? 'Assigning...' : 'Assign' }}
+    <button type="button" class="btn btn-light btn-sm" (click)="c('Close click')" [disabled]="isAssigning">Close</button>
+
+    <!-- Phase 1 footer: Assign button -->
+    <button *ngIf="!showAssignConfirmation && !isAssigning && assignmentResults.length === 0"
+      type="button" class="btn btn-success btn-sm"
+      [disabled]="!assignDeviceIds.trim()"
+      (click)="prepareAssignment()">
+      <i class="fas fa-link"></i> Assign
+    </button>
+
+    <!-- Phase 2 footer: Back + Confirm -->
+    <ng-container *ngIf="showAssignConfirmation && !isAssigning">
+      <button type="button" class="btn btn-secondary btn-sm" (click)="showAssignConfirmation = false">
+        <i class="fas fa-arrow-left"></i> Back
+      </button>
+      <button type="button" class="btn btn-success btn-sm" (click)="executeAssignment()">
+        <i class="fas fa-check"></i> Confirm
+      </button>
+    </ng-container>
+
+    <!-- Phase 3 footer: Assign More -->
+    <button *ngIf="assignmentResults.length > 0 && !isAssigning"
+      type="button" class="btn btn-outline-success btn-sm"
+      (click)="resetAssignModal()">
+      <i class="fas fa-plus"></i> Assign More
     </button>
   </div>
 </ng-template>

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -234,6 +234,8 @@ export class DeviceRequestInfoComponent {
   assignDeviceIds: string = '';
   assignmentResults: DeviceAssignmentResult[] = [];
   isAssigning: boolean = false;
+  showAssignConfirmation: boolean = false;
+  parsedDeviceIds: string[] = [];
 
   deviceTypes = [
     { key: 'deviceRequestItems.laptops', label: 'Laptops', icon: 'fas fa-laptop' },
@@ -1022,10 +1024,12 @@ export class DeviceRequestInfoComponent {
   openAssignDevicesModal() {
     this.assignDeviceIds = '';
     this.assignmentResults = [];
+    this.showAssignConfirmation = false;
+    this.parsedDeviceIds = [];
     this.modalService.open(this.assignDevicesModal, { centered: true, size: 'lg' });
   }
 
-  async assignDevices() {
+  prepareAssignment() {
     const ids = this.assignDeviceIds
       .split(',')
       .map(id => id.trim())
@@ -1035,13 +1039,25 @@ export class DeviceRequestInfoComponent {
       return;
     }
 
+    this.parsedDeviceIds = ids;
+    this.showAssignConfirmation = true;
+  }
+
+  resetAssignModal() {
+    this.assignDeviceIds = '';
+    this.assignmentResults = [];
+    this.showAssignConfirmation = false;
+    this.parsedDeviceIds = [];
+  }
+
+  async executeAssignment() {
     this.isAssigning = true;
+    this.showAssignConfirmation = false;
     this.assignmentResults = [];
 
-    // Call the mutation once per kit ID so each can succeed or fail independently
-    for (const kitId of ids) {
+    for (const kitId of this.parsedDeviceIds) {
       try {
-        await this.apollo.mutate({
+        const res = await this.apollo.mutate<any>({
           mutation: ASSIGN_KITS,
           variables: {
             data: {
@@ -1051,17 +1067,16 @@ export class DeviceRequestInfoComponent {
           },
         }).toPromise();
 
-        this.assignmentResults.push({
-          deviceId: kitId,
-          status: 'success',
-          message: 'Assigned successfully',
-        });
+        const assignedKits: { id: string }[] = res.data['assignKitsToDeviceRequest']['kits'];
+        const wasAssigned = assignedKits.some(k => String(k.id) === String(kitId));
+
+        if (wasAssigned) {
+          this.assignmentResults.push({ deviceId: kitId, status: 'success', message: 'Assigned successfully' });
+        } else {
+          this.assignmentResults.push({ deviceId: kitId, status: 'error', message: 'Device not found' });
+        }
       } catch (err) {
-        this.assignmentResults.push({
-          deviceId: kitId,
-          status: 'error',
-          message: err instanceof Error ? err.message : String(err),
-        });
+        this.assignmentResults.push({ deviceId: kitId, status: 'error', message: this.extractGraphQLError(err) });
       }
     }
 
@@ -1070,6 +1085,16 @@ export class DeviceRequestInfoComponent {
     }
 
     this.isAssigning = false;
+  }
+
+  private extractGraphQLError(err: any): string {
+    if (err && err.graphQLErrors && err.graphQLErrors.length > 0) {
+      return err.graphQLErrors[0].message;
+    }
+    if (err && err.networkError) {
+      return err.networkError.message || 'Network error';
+    }
+    return err instanceof Error ? err.message : String(err);
   }
 
   generatingPdf = false;


### PR DESCRIPTION
…n step

- Verify kit appears in returned kits list after mutation; report 'Device not found' if absent rather than falsely claiming success
- Extract GraphQL error messages from Apollo error objects so the real server reason is shown (e.g. validation failures, not-found messages)
- Split modal into three phases: input → confirmation → results; the confirmation screen shows 'You are about to assign N device(s) to request #X' with a full list before any mutations are fired
- Results panel builds up in real-time as each kit is processed; 'Assign More' button resets to input phase without closing the modal

https://claude.ai/code/session_01DfkKWFoDt5yqLRWdvpaQov