### PR TITLE
Fix status colour nth-child offset: +2 not +1

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -592,29 +592,29 @@ table.table.dataTable > tbody > tr.selected a {
 /* BUG-08 / BUG-16: Bootstrap 5 renamed .custom-control → .form-check.
    Additionally the formly form-field wrapper renders a <label> as the FIRST child of
    its container <div>, pushing every .form-check to nth-child(2) and above.
-   The selectors below are corrected by +1 on every position.
+   The selectors below are corrected by +2 on every position (two non-form-check elements precede the radios).
    margin-bottom:0 eliminates the white gaps Bootstrap 5 adds between .form-check items. */
 
 .device-request-status .form-check {
     margin-bottom: 0;
 }
-.device-request-status .form-check:nth-child(2) {
+.device-request-status .form-check:nth-child(3) {
     border-radius: 5px 5px 0 0;
     background-color: #FFEAB3;
 }
-.device-request-status .form-check:nth-child(3),
-.device-request-status .form-check:nth-child(4) {
+.device-request-status .form-check:nth-child(4),
+.device-request-status .form-check:nth-child(5) {
     background-color: #FFEAB3;
 }
-.device-request-status .form-check:nth-child(5),
-.device-request-status .form-check:nth-child(6) {
+.device-request-status .form-check:nth-child(6),
+.device-request-status .form-check:nth-child(7) {
     background-color: #BFCEF9;
 }
-.device-request-status .form-check:nth-child(7),
-.device-request-status .form-check:nth-child(8) {
+.device-request-status .form-check:nth-child(8),
+.device-request-status .form-check:nth-child(9) {
     background-color: #FBCBC0;
 }
-.device-request-status .form-check:nth-child(9) {
+.device-request-status .form-check:nth-child(10) {
     background-color: #FBCBC0;
     border-radius: 0 0 5px 5px;
 }
@@ -622,28 +622,28 @@ table.table.dataTable > tbody > tr.selected a {
 .kit-status .form-check {
     margin-bottom: 0;
 }
-.kit-status .form-check:nth-child(2) {
+.kit-status .form-check:nth-child(3) {
     border-radius: 5px 5px 0 0;
     background-color: #FFEAB3;
 }
-.kit-status .form-check:nth-child(3),
 .kit-status .form-check:nth-child(4),
 .kit-status .form-check:nth-child(5),
-.kit-status .form-check:nth-child(6) {
+.kit-status .form-check:nth-child(6),
+.kit-status .form-check:nth-child(7) {
     background-color: #FBCBC0;
 }
-.kit-status .form-check:nth-child(7),
-.kit-status .form-check:nth-child(8) {
+.kit-status .form-check:nth-child(8),
+.kit-status .form-check:nth-child(9) {
     background-color: #BFCEF9;
 }
-.kit-status .form-check:nth-child(9),
-.kit-status .form-check:nth-child(10) {
+.kit-status .form-check:nth-child(10),
+.kit-status .form-check:nth-child(11) {
     background-color: #BAE3D7;
 }
-.kit-status .form-check:nth-child(11) {
+.kit-status .form-check:nth-child(12) {
     background-color: #DDB4E7;
 }
-.kit-status .form-check:nth-child(12) {
+.kit-status .form-check:nth-child(13) {
     background-color: #DDB4E7;
     border-radius: 0 0 5px 5px;
 }


### PR DESCRIPTION
The formly wrapper renders two non-form-check elements before the radio buttons, so all nth-child selectors need to start at 3, not 2. The previous fix assumed only one preceding element (the label).

Evidence: with nth-child(2)=yellow the first item showed no yellow but did get salmon from the nth-child(3-6) salmon rule, confirming radios sit at DOM positions 3-13. Shifts all kit-status and device-request-status nth-child values up by one.

https://claude.ai/code/session_01YG2PsVWtQv4UcrT2p9MDFX