### PR TITLE
Fix device-request-status radio buttons bleeding outside coloured blocks

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -597,6 +597,7 @@ table.table.dataTable > tbody > tr.selected a {
 
 .device-request-status .form-check {
     margin-bottom: 0;
+    padding-left: 2rem;
 }
 .device-request-status .form-check:nth-child(3) {
     border-radius: 5px 5px 0 0;


### PR DESCRIPTION
Bootstrap 5 places .form-check-input at margin-left: -1.5em, which sits exactly at the left edge of the .form-check padding area. Increasing padding-left to 2rem shifts the radio 0.5rem inside the coloured background so it no longer bleeds over the left border.

https://claude.ai/code/session_01YG2PsVWtQv4UcrT2p9MDFX