### PR TITLE
Refactor data transformation to use map instead of forEach

### DIFF
--- a/src/app/views/corewidgets/components/device-request-index/device-request-index.component.ts
+++ b/src/app/views/corewidgets/components/device-request-index/device-request-index.component.ts
@@ -281,21 +281,20 @@ export class DeviceRequestIndexComponent {
             if (!this.total) {
               this.total = data['totalElements'];
             }
-            data.content.forEach(d => {
-              d.types = {};
-              d.kitIds = {};
+            this.entities = data.content.map(d => {
+              const types: Record<string, number> = {};
+              const kitIds: Record<string, string[]> = {};
               if (d.kits && d.kits.length) {
                 d.kits.forEach(k => {
                   const typeMap: Record<string, string> = { 'SMARTPHONE': 'PHONES' };
                   const t = typeMap[k.type] || `${k.type}S`;
-                  d.types[t] = d.types[t] || 0;
-                  d.types[t]++;
-                  d.kitIds[t] = d.kitIds[t] || [];
-                  d.kitIds[t].push(k.id);
+                  types[t] = (types[t] || 0) + 1;
+                  kitIds[t] = kitIds[t] || [];
+                  kitIds[t].push(k.id);
                 });
               }
+              return { ...d, types, kitIds };
             });
-            this.entities = data.content;
           }
 
           callback({

--- a/src/app/views/corewidgets/components/distributions-and-deliveries-index/distributions-and-deliveries-index.component.ts
+++ b/src/app/views/corewidgets/components/distributions-and-deliveries-index/distributions-and-deliveries-index.component.ts
@@ -452,21 +452,20 @@ export class DistributionsAndDeliveriesIndexComponent {
           let data: any = {};
           if (res.data) {
             data = res['data']['deviceRequestConnection'];
-            data.content.forEach(d => {
-              d.types = {};
-              d.kitIds = {};
+            this.entities = data.content.map(d => {
+              const types: Record<string, number> = {};
+              const kitIds: Record<string, string[]> = {};
               if (d.kits && d.kits.length) {
                 d.kits.forEach(k => {
                   const typeMap: Record<string, string> = { 'SMARTPHONE': 'PHONES' };
                   const t = typeMap[k.type] || `${k.type}S`;
-                  d.types[t] = d.types[t] || 0;
-                  d.types[t]++;
-                  d.kitIds[t] = d.kitIds[t] || [];
-                  d.kitIds[t].push(k.id);
+                  types[t] = (types[t] || 0) + 1;
+                  kitIds[t] = kitIds[t] || [];
+                  kitIds[t].push(k.id);
                 });
               }
+              return { ...d, types, kitIds };
             });
-            this.entities = data.content;
           }
 
           callback({

--- a/src/app/views/corewidgets/components/donor-parent-index/donor-parent-index.component.ts
+++ b/src/app/views/corewidgets/components/donor-parent-index/donor-parent-index.component.ts
@@ -301,16 +301,10 @@ export class DonorParentIndexComponent {
               this.total = data['totalElements'];
             }
 
-            data.content.forEach(d => {
-              d.deviceCount = 0;
-              if (d.donors && d.donors.length) {
-                d.donors.forEach(k => {
-                  d.deviceCount += k.kitCount;
-                });
-              }
-            });
-
-            this.entities = data.content;
+            this.entities = data.content.map(d => ({
+              ...d,
+              deviceCount: d.donors ? d.donors.reduce((sum, k) => sum + k.kitCount, 0) : 0
+            }));
           }
 
           callback({

--- a/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
+++ b/src/app/views/corewidgets/components/kit-index/kit-index.component.ts
@@ -895,12 +895,10 @@ export class KitIndexComponent {
             if (!this.total) {
               this.total = data['totalElements'];
             }
-            data.content.forEach(d => {
-              if (d.donor) {
-                d.donorName = this.donorName(d.donor);
-              }
-            });
-            this.entities = data.content;
+            this.entities = data.content.map(d => ({
+              ...d,
+              donorName: d.donor ? this.donorName(d.donor) : undefined
+            }));
             this.allPageSelected = this.entities.length > 0 && this.entities.every(e => !!this.selections[e.id]);
           }
 


### PR DESCRIPTION
## Summary
Refactored data transformation logic across four components to use functional `map()` operations instead of imperative `forEach()` loops. This improves code readability, reduces side effects, and follows functional programming best practices.

## Key Changes
- **device-request-index.component.ts**: Converted `forEach` loop to `map()` that transforms kit data into `types` and `kitIds` objects, returning enriched entities in a single operation
- **distributions-and-deliveries-index.component.ts**: Applied the same refactoring pattern for kit data transformation as device-request-index
- **donor-parent-index.component.ts**: Simplified device count calculation using `reduce()` within a `map()` operation, eliminating intermediate variable mutations
- **kit-index.component.ts**: Refactored donor name assignment to use `map()` with conditional logic, removing imperative mutations

## Implementation Details
- All transformations now use immutable patterns with spread operators (`...d`) to create new objects rather than mutating existing ones
- Local variables (`types`, `kitIds`, `deviceCount`) are scoped within the map function instead of being assigned to the data object
- Conditional logic is preserved using ternary operators where needed
- The refactoring maintains identical functionality while improving code clarity and reducing side effects

https://claude.ai/code/session_01QJDzX7yR8emF3ni8QoFF7r