### PR TITLE
Add global backend warm-up interstitial via BackendStatusService

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,7 +10,31 @@
             <app-header></app-header>
             <!-- Begin Page Content -->
             <div class="container-fluid">
-                <router-outlet></router-outlet>
+                @if (backendStatus === 'checking') {
+                    <div class="row d-flex justify-content-center align-items-center" style="min-height: 60vh;">
+                        <div class="col-lg-5 col-md-8 text-center">
+                            <div class="card shadow p-5">
+                                <div class="spinner-border text-primary mb-4 mx-auto" role="status" style="width: 3rem; height: 3rem;">
+                                    <span class="visually-hidden">Loading…</span>
+                                </div>
+                                <h5 class="text-primary mb-2">Server is starting up</h5>
+                                <p class="text-muted mb-0">{{ backendStatusService.statusMessage }}</p>
+                            </div>
+                        </div>
+                    </div>
+                } @else if (backendStatus === 'error') {
+                    <div class="row d-flex justify-content-center align-items-center" style="min-height: 60vh;">
+                        <div class="col-lg-5 col-md-8 text-center">
+                            <div class="card shadow p-5">
+                                <p class="text-muted">The server is taking longer than expected to respond.</p>
+                                <p class="text-muted mb-3">Please try again in a few minutes, or click below to retry now.</p>
+                                <button class="btn btn-primary btn-sm" (click)="backendStatusService.startCheck()">Retry</button>
+                            </div>
+                        </div>
+                    </div>
+                } @else {
+                    <router-outlet></router-outlet>
+                }
             </div>
             <!-- /.container-fluid -->
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,10 +9,10 @@ import { Title } from '@angular/platform-browser';
 import { filter, map } from "rxjs/operators";
 import { AppInsightsService } from '@app/shared/services/app-insights.service';
 import { ConfigService } from '@app/shared/services/config.service';
-import { NgZone } from '@angular/core';
 import { NgProgressComponent } from 'ngx-progressbar';
 import { AppSidebar } from './components/app-sidebar/app.sidebar.component';
 import { AppHeader } from './components/app-header/app.header.component';
+import { BackendStatusService, BackendStatus } from '@app/shared/services/backend-status.service';
 
 @Component({
     selector: 'app-root',
@@ -24,6 +24,8 @@ export class AppComponent {
   private actionSub: Subscription;
   version = APP_VERSION;
   apiVersion = '';
+  backendStatus: BackendStatus = 'checking';
+
   constructor(
     private toastr: ToastrService,
     private store: Store,
@@ -33,7 +35,7 @@ export class AppComponent {
     private activatedRoute: ActivatedRoute,
     private appInsights: AppInsightsService,
     private config: ConfigService,
-    private zone: NgZone
+    readonly backendStatusService: BackendStatusService
   ) {
     titleService.setTitle("TaDa");
 
@@ -61,34 +63,25 @@ export class AppComponent {
 
   ngOnInit() {
     this.actionSub = this.actions.pipe(ofAction(RouterNavigation)).subscribe(({ event }) => this.handleAction(event));
-    this.fetchBuildInfo();
-  }
 
-  private fetchBuildInfo() {
-    const endpoint = this.config.environment.graphql_endpoint;
-    fetch(endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: '{ buildInfo { version commit time } }' })
-    })
-      .then(res => res.json())
-      .then(res => {
-        this.zone.run(() => {
-          if (res && res.data && res.data.buildInfo) {
-            const info = res.data.buildInfo;
-            const time = info.time ? ' ' + info.time.replace(/T.*/, '') : '';
-            this.apiVersion = `${info.version} (${info.commit})${time}`;
-          } else {
-            this.apiVersion = 'unavailable';
-          }
-        });
+    this.actionSub.add(
+      this.backendStatusService.status$.subscribe(status => {
+        this.backendStatus = status;
       })
-      .catch(err => {
-        console.warn('Failed to fetch buildInfo:', err);
-        this.zone.run(() => {
+    );
+
+    this.actionSub.add(
+      this.backendStatusService.buildInfo$.subscribe(info => {
+        if (info) {
+          const time = info.time ? ' ' + info.time.replace(/T.*/, '') : '';
+          this.apiVersion = `${info.version} (${info.commit})${time}`;
+        } else if (this.backendStatus === 'error') {
           this.apiVersion = 'unavailable';
-        });
-      });
+        }
+      })
+    );
+
+    this.backendStatusService.startCheck();
   }
 
   handleAction(action) {
@@ -111,6 +104,7 @@ export class AppComponent {
     if (this.actionSub) {
       this.actionSub.unsubscribe();
     }
+    this.backendStatusService.cleanup();
   }
 
 }

--- a/src/app/shared/services/backend-status.service.ts
+++ b/src/app/shared/services/backend-status.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, NgZone } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ConfigService } from './config.service';
+
+export type BackendStatus = 'checking' | 'ready' | 'error';
+
+@Injectable({ providedIn: 'root' })
+export class BackendStatusService {
+  private readonly POLL_INTERVAL_MS = 4000;
+  private readonly MAX_ATTEMPTS = 15;
+
+  private attempt = 0;
+  private pollTimer: any;
+  private abortController: AbortController | null = null;
+
+  /** Emits 'checking' on start, 'ready' on first success, 'error' after MAX_ATTEMPTS failures. */
+  readonly status$ = new BehaviorSubject<BackendStatus>('checking');
+
+  /**
+   * The parsed buildInfo from the last successful probe.
+   * AppComponent uses this to populate the version footer without a second round-trip.
+   */
+  readonly buildInfo$ = new BehaviorSubject<{ version: string; commit: string; time: string } | null>(null);
+
+  constructor(private zone: NgZone, private config: ConfigService) {}
+
+  /** User-facing message that progresses as attempts accumulate. */
+  get statusMessage(): string {
+    if (this.attempt < 3) return 'Starting up… this usually takes about 30 seconds.';
+    if (this.attempt < 8) return 'Still warming up… almost there.';
+    return 'Taking a bit longer than usual, please hang on…';
+  }
+
+  /** Start (or restart) the health-check poll cycle from scratch. */
+  startCheck() {
+    this.cleanup();
+    this.attempt = 0;
+    this.status$.next('checking');
+    this.poll();
+  }
+
+  private poll() {
+    this.abortController = new AbortController();
+    const endpoint = this.config.environment.graphql_endpoint;
+
+    fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: '{ buildInfo { version commit time } }' }),
+      signal: this.abortController.signal
+    })
+      .then(res => res.json())
+      .then(res => {
+        this.zone.run(() => {
+          if (res?.data?.buildInfo) {
+            this.buildInfo$.next(res.data.buildInfo);
+            this.status$.next('ready');
+          } else {
+            this.scheduleRetry();
+          }
+        });
+      })
+      .catch(err => {
+        if (err?.name === 'AbortError') return;
+        this.zone.run(() => this.scheduleRetry());
+      });
+  }
+
+  private scheduleRetry() {
+    this.attempt++;
+    if (this.attempt >= this.MAX_ATTEMPTS) {
+      this.status$.next('error');
+      return;
+    }
+    this.pollTimer = setTimeout(() => this.poll(), this.POLL_INTERVAL_MS);
+  }
+
+  /** Cancel any pending poll timer and in-flight fetch. Safe to call multiple times. */
+  cleanup() {
+    clearTimeout(this.pollTimer);
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+}


### PR DESCRIPTION
Extracts the polling pattern from org-request into a shared, injectable BackendStatusService that probes POST /api/graphql (buildInfo query) on a 4 s interval, up to 15 attempts (~60 s total).

AppComponent now uses the service instead of its one-shot fetchBuildInfo(). While the backend is unreachable the content area (router-outlet) is replaced by a centred spinner card with a progressively-updated status message; sidebar and header remain visible since they are driven by Auth0/NGXS state. After 60 s of failures an error card is shown with a Retry button. The successful buildInfo response is piped back to AppComponent so the version footer is still populated without a second round-trip.

https://claude.ai/code/session_016GGfVV7UFZmvxsbZaErvXh