### PR TITLE
Back-port device assignment modal and en-GB date formatting from master

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
@@ -27,6 +27,12 @@
                   </h6>
                 </div>
                 <div>
+                  @if (user?.authorities['app:bulkedit']) {
+                    <button (click)="openAssignDevicesModal()"
+                      type="button" class="btn btn-success btn-sm me-2">
+                      <small><i class="fas fa-link"></i> Assign Devices</small>
+                    </button>
+                  }
                   <button [disabled]="generatingPdf" (click)="generatePDF()"
                     type="button" class="btn btn-info btn-sm me-2">
                     <small>
@@ -140,5 +146,108 @@
   <div class="modal-footer">
     <button type="button" class="btn btn-light btn-sm" (click)="c('Close click')">CANCEL</button>
     <button type="button" class="btn btn-danger btn-sm" (click)="deleteEntity(); c('Close click')">YES, DELETE</button>
+  </div>
+</ng-template>
+
+<ng-template #assignDevicesModal let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <h4 class="modal-title">Assign Devices to Request #{{requestId}}</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="d('Cross click')" [disabled]="isAssigning"></button>
+  </div>
+  <div class="modal-body">
+
+    <!-- Phase 1: Input -->
+    @if (!showAssignConfirmation && assignmentResults.length === 0) {
+      <div class="form-group">
+        <label for="assignDeviceInput"><strong>Device IDs</strong> (comma-separated)</label>
+        <textarea
+          id="assignDeviceInput"
+          class="form-control"
+          rows="3"
+          placeholder="e.g. 1234, 5678, 9012"
+          [value]="assignDeviceIds"
+          (input)="assignDeviceIds = $event.target['value']">
+        </textarea>
+        <small class="form-text text-muted">Enter the IDs of devices to assign to this request, separated by commas.</small>
+      </div>
+    }
+
+    <!-- Phase 2: Confirmation -->
+    @if (showAssignConfirmation && !isAssigning) {
+      <div class="alert alert-warning">
+        <i class="fas fa-exclamation-triangle me-1"></i>
+        You are about to assign <strong>{{parsedDeviceIds.length}}</strong> device(s) to request <strong>#{{requestId}}</strong>. Click <strong>Confirm</strong> to continue.
+      </div>
+      <div class="border rounded p-2 bg-light" style="max-height: 180px; overflow-y: auto; font-family: monospace; font-size: 0.85rem;">
+        @for (id of parsedDeviceIds; track id) {
+          <div class="mb-1">
+            <i class="fas fa-hdd text-secondary me-1"></i> Device {{id}}
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Phase 3: Results (builds up during and after assignment) -->
+    @if (isAssigning || assignmentResults.length > 0) {
+      <div>
+        @if (isAssigning) {
+          <div class="mb-2 text-muted small">
+            <i class="fas fa-spinner fa-spin me-1"></i>
+            Assigning... ({{assignmentResults.length}} of {{parsedDeviceIds.length}} done)
+          </div>
+        }
+        @if (assignmentResults.length > 0) {
+          <div>
+            <h6 class="font-weight-bold">Assignment Results:</h6>
+            <div class="border rounded p-2" style="max-height: 240px; overflow-y: auto; background: #f8f9fa; font-family: monospace; font-size: 0.85rem;">
+              @for (result of assignmentResults; track result.deviceId) {
+                <div class="mb-1"
+                     [class.text-success]="result.status === 'success'"
+                     [class.text-warning]="result.status === 'warning'"
+                     [class.text-danger]="result.status === 'error'">
+                  <i [class.fas]="true"
+                     [class.fa-check-circle]="result.status === 'success'"
+                     [class.fa-exclamation-triangle]="result.status === 'warning'"
+                     [class.fa-times-circle]="result.status === 'error'"></i>
+                  <strong> Device {{result.deviceId}}:</strong> {{result.message}}
+                </div>
+              }
+            </div>
+            <small class="form-text text-muted mt-1">{{assignmentResults.length}} device(s) processed</small>
+          </div>
+        }
+      </div>
+    }
+
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-light btn-sm" (click)="c('Close click')" [disabled]="isAssigning">Close</button>
+
+    <!-- Phase 1 footer: Assign button -->
+    @if (!showAssignConfirmation && !isAssigning && assignmentResults.length === 0) {
+      <button type="button" class="btn btn-success btn-sm"
+        [disabled]="!assignDeviceIds.trim()"
+        (click)="prepareAssignment()">
+        <i class="fas fa-link"></i> Assign
+      </button>
+    }
+
+    <!-- Phase 2 footer: Back + Confirm -->
+    @if (showAssignConfirmation && !isAssigning) {
+      <button type="button" class="btn btn-secondary btn-sm" (click)="showAssignConfirmation = false">
+        <i class="fas fa-arrow-left"></i> Back
+      </button>
+      <button type="button" class="btn btn-success btn-sm" (click)="executeAssignment()">
+        <i class="fas fa-check"></i> Confirm
+      </button>
+    }
+
+    <!-- Phase 3 footer: Assign More -->
+    @if (assignmentResults.length > 0 && !isAssigning) {
+      <button type="button" class="btn btn-outline-success btn-sm"
+        (click)="resetAssignModal()">
+        <i class="fas fa-plus"></i> Assign More
+      </button>
+    }
   </div>
 </ng-template>

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -155,6 +155,17 @@ const DELETE_ENTITY = gql`
   }
 `;
 
+const ASSIGN_KITS = gql`
+  mutation assignKitsToDeviceRequest($data: BulkKitAssignmentInput!) {
+    assignKitsToDeviceRequest(data: $data) {
+      id
+      kits {
+        id
+      }
+    }
+  }
+`;
+
 const QUERY_DEVICE_COUNT = gql`
   query countDevicesForRequest($deviceRequestId: Long) {
     kitsConnection(where: { deviceRequest: { id: { _eq: $deviceRequestId } } }) {
@@ -187,6 +198,12 @@ query findAutocompleteReferringOrganisationContacts($term: String, $referringOrg
 }
 `;
 
+export interface DeviceAssignmentResult {
+  deviceId: string;
+  status: 'success' | 'warning' | 'error';
+  message: string;
+}
+
 @Component({
     selector: 'app-device-request-info',
     templateUrl: './device-request-info.component.html',
@@ -195,6 +212,7 @@ query findAutocompleteReferringOrganisationContacts($term: String, $referringOrg
 })
 export class DeviceRequestInfoComponent {
   @ViewChild('kitWarning') kitWarningModal: any;
+  @ViewChild('assignDevicesModal') assignDevicesModal: any;
 
   private clickHandler: (e: MouseEvent) => void;
 
@@ -225,6 +243,12 @@ export class DeviceRequestInfoComponent {
   @Select(UserState.user) user$: Observable<User>;
   showAllDeviceTypes = false;
   deviceCount: number = 0;
+
+  assignDeviceIds: string = '';
+  assignmentResults: DeviceAssignmentResult[] = [];
+  isAssigning: boolean = false;
+  showAssignConfirmation: boolean = false;
+  parsedDeviceIds: string[] = [];
 
   deviceTypes = [
     { key: 'deviceRequestItems.laptops', label: 'Laptops', icon: 'fas fa-laptop' },
@@ -992,6 +1016,82 @@ export class DeviceRequestInfoComponent {
       );
   }
 
+  openAssignDevicesModal() {
+    this.assignDeviceIds = '';
+    this.assignmentResults = [];
+    this.showAssignConfirmation = false;
+    this.parsedDeviceIds = [];
+    this.modalService.open(this.assignDevicesModal, { centered: true, size: 'lg' });
+  }
+
+  prepareAssignment() {
+    const ids = this.assignDeviceIds
+      .split(',')
+      .map(id => id.trim())
+      .filter(id => id.length > 0);
+
+    if (ids.length === 0) {
+      return;
+    }
+
+    this.parsedDeviceIds = ids;
+    this.showAssignConfirmation = true;
+  }
+
+  resetAssignModal() {
+    this.assignDeviceIds = '';
+    this.assignmentResults = [];
+    this.showAssignConfirmation = false;
+    this.parsedDeviceIds = [];
+  }
+
+  async executeAssignment() {
+    this.isAssigning = true;
+    this.showAssignConfirmation = false;
+    this.assignmentResults = [];
+
+    for (const kitId of this.parsedDeviceIds) {
+      try {
+        const res = await this.apollo.mutate<any>({
+          mutation: ASSIGN_KITS,
+          variables: {
+            data: {
+              deviceRequestId: this.requestId,
+              kitIds: [kitId],
+            },
+          },
+        }).toPromise();
+
+        const assignedKits: { id: string }[] = res.data['assignKitsToDeviceRequest']['kits'];
+        const wasAssigned = assignedKits.some(k => String(k.id) === String(kitId));
+
+        if (wasAssigned) {
+          this.assignmentResults.push({ deviceId: kitId, status: 'success', message: 'Assigned successfully' });
+        } else {
+          this.assignmentResults.push({ deviceId: kitId, status: 'error', message: 'Device not found' });
+        }
+      } catch (err) {
+        this.assignmentResults.push({ deviceId: kitId, status: 'error', message: this.extractGraphQLError(err) });
+      }
+    }
+
+    if (this.assignmentResults.some(r => r.status === 'success')) {
+      this.fetchDeviceCount();
+    }
+
+    this.isAssigning = false;
+  }
+
+  private extractGraphQLError(err: any): string {
+    if (err && err.graphQLErrors && err.graphQLErrors.length > 0) {
+      return err.graphQLErrors[0].message;
+    }
+    if (err && err.networkError) {
+      return err.networkError.message || 'Network error';
+    }
+    return err instanceof Error ? err.message : String(err);
+  }
+
   generatingPdf = false;
 
   async generatePDF() {
@@ -1012,7 +1112,7 @@ export class DeviceRequestInfoComponent {
       const pdfData = {
         // Header fields
         organisationName: this.model.referringOrganisationContact?.referringOrganisation?.name || 'N/A',
-        date: this.model.collectionDate ? new Date(this.model.collectionDate).toLocaleDateString() : 'N/A',
+        date: this.model.collectionDate ? new Date(this.model.collectionDate).toLocaleDateString('en-GB') : 'N/A',
 
         // Device Request details
         requestId: this.requestId,


### PR DESCRIPTION
## Summary

Two enhancements were added on `master` *after* `dev` was re-initialised for the major Angular/library upgrade, so they were never carried into the upgraded codebase (the two branches share no git history). This back-ports them, adapted to the upgraded stack.

- **Device assignment modal** (master PR#28/#29): adds an "Assign Devices" button gated behind `app:bulkedit` on the device-request-info page, wired to the `assignKitsToDeviceRequest` mutation with a 3-phase input → confirm → results flow. Adapted to the upgraded stack: Bootstrap 5 classes (`me-*`, `btn-close`), Angular `@if`/`@for` control flow.
- **Force British date formatting** (master `369a760`): collection date in the generated PDF now uses `toLocaleDateString('en-GB')`.

The May PDF-kits fix and the SWA-deploy change were already independently re-implemented on `dev`, so they are not included here.

## Test plan

- [x] `ng build --configuration production` compiles cleanly
- [ ] Verify `assignKitsToDeviceRequest` exists on the migrated Azure GraphQL schema (UAT)
- [ ] Manually exercise the modal flow on UAT: button visible only with `app:bulkedit`; input → confirm → per-device results; error handling via GraphQL errors
- [ ] Verify generated PDF renders the collection date as DD/MM/YYYY

https://claude.ai/code/session_019YivtUJu1xFUTnzVe8dyzc

---
_Generated by [Claude Code](https://claude.ai/code/session_019YivtUJu1xFUTnzVe8dyzc)_