### PR TITLE
Fix missing left padding on kit-status radio buttons

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -622,6 +622,7 @@ table.table.dataTable > tbody > tr.selected a {
 
 .kit-status .form-check {
     margin-bottom: 0;
+    padding-left: 2rem;
 }
 .kit-status .form-check:nth-child(3) {
     border-radius: 5px 5px 0 0;


### PR DESCRIPTION
The .kit-status .form-check rule was missing padding-left: 2rem, which was already present on .device-request-status .form-check. This caused the radio buttons on the device page to overflow their coloured background boxes on the left side.

https://claude.ai/code/session_011QKKbkWnSubBoyjvKTBq7q