### PR TITLE
Fix kit-info: untick stays disabled + Save sends type=null

### DIFF
--- a/e2e/tests/kit-locked-status.spec.ts
+++ b/e2e/tests/kit-locked-status.spec.ts
@@ -63,7 +63,11 @@ const SUBSTATUS_UNFLAGGED = {
   lockedToUser: false,
 };
 
-async function installGraphqlMocks(page: import('@playwright/test').Page, subStatus: any) {
+async function installGraphqlMocks(
+  page: import('@playwright/test').Page,
+  subStatus: any,
+  capturedMutations?: { body: any }[],
+) {
   await page.route('**/graphql', async route => {
     const body = route.request().postData() ?? '';
     if (body.includes('buildInfo')) {
@@ -79,6 +83,19 @@ async function installGraphqlMocks(page: import('@playwright/test').Page, subSta
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ data: { kit: { ...KIT_BASE, subStatus } } }),
+      });
+      return;
+    }
+    if (body.includes('updateKit')) {
+      let parsed: any = null;
+      try { parsed = JSON.parse(body); } catch {}
+      if (parsed && capturedMutations) capturedMutations.push({ body: parsed });
+      const sent = parsed?.variables?.data ?? {};
+      const merged = { ...KIT_BASE, ...sent, subStatus: { ...subStatus, ...(sent.subStatus || {}) } };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { updateKit: merged } }),
       });
       return;
     }
@@ -143,4 +160,47 @@ test('unlocked kit: status radios enabled and banner hidden', async ({ page }) =
   expect(r.nfiChecked, 'needsFurtherInvestigation checkbox should be unchecked').toBe(false);
   expect(r.anyStatusDisabled, 'no status radio should be disabled when nothing is locked').toBe(false);
   expect(r.bannerVisible, '"Status locked" banner should be hidden').toBe(false);
+});
+
+test('toggling NFI off re-enables radios and hides banner without saving', async ({ page }) => {
+  test.setTimeout(60_000);
+  await installGraphqlMocks(page, { ...SUBSTATUS_UNFLAGGED, needsFurtherInvestigation: true });
+
+  await page.goto('/dashboard/devices/2129');
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  // Locked: radios disabled, banner visible.
+  let r = await probe(page);
+  expect(r.allStatusDisabled).toBe(true);
+  expect(r.bannerVisible).toBe(true);
+
+  // Untick the NFI checkbox via Angular forms (not the UI click — the change
+  // handler matters but the assertion here is that Formly's expression
+  // re-evaluates from the model, regardless of who toggled the control).
+  await page.locator('label:has-text("Needs further investigation") + input[type="checkbox"], label:has-text("Needs further investigation") ~ input[type="checkbox"]').first().uncheck();
+  await page.waitForTimeout(500);
+
+  r = await probe(page);
+  expect(r.nfiChecked, 'NFI should now be unchecked').toBe(false);
+  expect(r.anyStatusDisabled, 'radios should re-enable as soon as NFI is unchecked, before Save').toBe(false);
+  expect(r.bannerVisible, 'banner should hide as soon as NFI is unchecked').toBe(false);
+});
+
+test('Save sends the device type — type field is not coerced to null', async ({ page }) => {
+  test.setTimeout(60_000);
+  const captured: { body: any }[] = [];
+  await installGraphqlMocks(page, SUBSTATUS_UNFLAGGED, captured);
+
+  await page.goto('/dashboard/devices/2129');
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  await page.locator('button:has-text("Save")').first().click();
+  await page.waitForTimeout(1500);
+
+  expect(captured.length, 'updateKit mutation should fire on Save').toBeGreaterThan(0);
+  const sentData = captured[0].body?.variables?.data;
+  expect(sentData, 'mutation must carry a data variable').toBeTruthy();
+  expect(sentData.type, 'data.type must not be null (KitType! is NonNull)').toBe('LAPTOP');
 });

--- a/src/app/views/corewidgets/components/kit-info/custom-kit-info-input.ts
+++ b/src/app/views/corewidgets/components/kit-info/custom-kit-info-input.ts
@@ -38,7 +38,7 @@ Ideally, the input field should be dynamically rendered using custom selector bu
     <div style="font-size:smaller" class="d-flex">
   
       @if (to.type=='select') {
-        <select [hidden]="!editable" (focusout)="toggleEdit()" [formControl]="formControl" [formlyAttributes]="field" [(ngModel)]="infoValue">
+        <select [hidden]="!editable" (focusout)="toggleEdit()" [formControl]="formControl" [formlyAttributes]="field">
           @for (val of to.options; track val) {
             <option
               [value]="val.value" >
@@ -47,14 +47,14 @@ Ideally, the input field should be dynamically rendered using custom selector bu
           }
         </select>
       }
-  
+
       @if (to.type!='select') {
-        <input [hidden]="!editable" (focusout)="toggleEdit()" [type]="to.type" [formControl]="formControl" [formlyAttributes]="field" [(ngModel)]="infoValue">
+        <input [hidden]="!editable" (focusout)="toggleEdit()" [type]="to.type" [formControl]="formControl" [formlyAttributes]="field">
       }
-      @if (infoValue != undefined) {
-        <span [hidden]="editable" class="pr-1"  [innerText]="infoValue"></span>
+      @if (formControl.value != null && formControl.value !== '') {
+        <span [hidden]="editable" class="pr-1"  [innerText]="formControl.value"></span>
       }
-      @if (infoValue == undefined) {
+      @if (formControl.value == null || formControl.value === '') {
         <span [hidden]="editable" class="pr-1 pl-1">None</span>
       }
       @if (to.descriptor) {
@@ -74,8 +74,6 @@ Ideally, the input field should be dynamically rendered using custom selector bu
     imports: [ReactiveFormsModule, FormlyModule]
 })
 export class FormlyCustomKitInfoType extends FieldType<FieldTypeConfig> {
-//
-    infoValue: string;
     editable: boolean = false;
     choice: boolean = false;
     

--- a/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
@@ -356,7 +356,10 @@ export class KitInfoComponent {
       show: true,
     },
     expressionProperties: {
-      'templateOptions.disabled': () => this.disabledStatuses,
+      'templateOptions.disabled': (model) => {
+        const s = model?.subStatus || {};
+        return !!(s.needsFurtherInvestigation || s.needsSparePart || s.installationOfOSFailed || s.wipeFailed || s.lockedToUser);
+      },
       'validation.show': 'model.showErrorState'
     }
   }
@@ -561,8 +564,9 @@ export class KitInfoComponent {
                   <small><strong>Status locked:</strong> Status changes are disabled while one or more flags are enabled (Device wipe failed, OS Installation failed, Needs further investigation, or Needs spare part).</small>
                 </div>
               `,
-              hideExpression: (model, state, field) => {
-                return !this.disabledStatuses;
+              hideExpression: (model) => {
+                const s = model?.subStatus || {};
+                return !(s.needsFurtherInvestigation || s.needsSparePart || s.installationOfOSFailed || s.wipeFailed || s.lockedToUser);
               }
             }
           ]


### PR DESCRIPTION
## Summary

Two follow-on bugs from PR #46:

1. **Untick keeps radios disabled until Save** — `expressionProperties` on the status field and the banner's `hideExpression` both read `this.disabledStatuses`, a component flag updated by the checkbox's `change` callback. Formly evaluates expressionProperties on form `valueChanges` which fires **before** the `change` callback, so on the tick that toggles the box the expression sees the stale flag. Fix: read the lock state from the `model` arg Formly already passes to the expression — no component-property indirection.

2. **Save submits `type: null` → "KitType!" coercion error** — `custom-kit-info-input.ts` had the same `[formControl]` + `[(ngModel)]="infoValue"` dual binding that I removed from `custom-kit-checkbox` in #46. `infoValue` is uninitialised, so NgModel can write `undefined` into the FormControl during init, leaving `data.type` null on the next `getRawValue()`. Drop `[(ngModel)]` and drive the read-only display span from `formControl.value`.

## Test plan

- [x] `ng build --configuration production` clean
- [x] Two new Playwright regressions added to `e2e/tests/kit-locked-status.spec.ts`:
  - `toggling NFI off re-enables radios and hides banner without saving`
  - `Save sends the device type — type field is not coerced to null`
- [x] Both confirmed to **fail** against the previous source and **pass** after the fix; the two existing tests still pass
- [ ] Manually verify on UAT: open device 2129, untick "Needs further investigation", radios re-enable + banner disappears immediately; click Save → no error

https://claude.ai/code/session_01WZqoWHiXkoATTNieGqgfYA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZqoWHiXkoATTNieGqgfYA)_