### PR TITLE
Fix kit-info: surface required-field feedback on Save (#49)

### DIFF
--- a/e2e/tests/kit-required-field-feedback.spec.ts
+++ b/e2e/tests/kit-required-field-feedback.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression: kit-info Save button must give clear feedback when required
+ * fields are empty (issue #49).
+ *
+ * Before the fix, the Save button was bound to `[disabled]="form.invalid"`, so
+ * an empty mandatory field (e.g. `subStatus.network` on a SMARTPHONE) silently
+ * disabled the button. A volunteer trying to save device 20031 → request 6526
+ * saw "the button does not appear to work" with no explanation.
+ *
+ * After the fix:
+ *   - Save remains clickable even when the form is invalid.
+ *   - Clicking it on an invalid form shows an error toast naming the missing
+ *     required fields and does NOT fire the updateKit mutation.
+ *   - Clicking it on a valid form still fires updateKit as before.
+ */
+import { test, expect } from '@playwright/test';
+
+const KIT_BASE = {
+  id: 20031,
+  type: 'SMARTPHONE',
+  status: 'PROCESSING_OS_INSTALLED',
+  model: 'Pixel 6',
+  location: 'BANK',
+  createdAt: '2025-01-01T00:00:00Z',
+  updatedAt: '2025-01-01T00:00:00Z',
+  age: 3,
+  archived: false,
+  make: 'Google',
+  deviceVersion: null,
+  serialNo: 'SN-20031',
+  storageCapacity: 128,
+  typeOfStorage: 'SSD',
+  ramCapacity: 8,
+  cpuType: 'Tensor',
+  cpuCores: 8,
+  tpmVersion: 0,
+  batteryHealth: 90,
+  lotId: null,
+  locationCode: 'A1',
+  donor: null,
+  deviceRequest: null,
+  attributes: { credentials: '', status: '', notes: '', network: '', state: '', otherType: '' },
+  notes: [],
+};
+
+const SUBSTATUS_EMPTY_NETWORK = {
+  installationOfOSFailed: false,
+  wipeFailed: false,
+  needsSparePart: false,
+  needsFurtherInvestigation: false,
+  network: null,
+  installedOSName: [],
+  lockedToUser: false,
+};
+
+const SUBSTATUS_WITH_NETWORK = {
+  ...SUBSTATUS_EMPTY_NETWORK,
+  network: 'UNLOCKED',
+};
+
+async function installGraphqlMocks(
+  page: import('@playwright/test').Page,
+  subStatus: any,
+  capturedMutations: { body: any }[],
+) {
+  await page.route('**/graphql', async route => {
+    const body = route.request().postData() ?? '';
+    if (body.includes('buildInfo')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { buildInfo: { version: '1.0.0-test', commit: 'abc123', time: '2026-01-01T00:00:00Z' } } }),
+      });
+      return;
+    }
+    if (body.includes('findKit')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { kit: { ...KIT_BASE, subStatus } } }),
+      });
+      return;
+    }
+    if (body.includes('updateKit')) {
+      let parsed: any = null;
+      try { parsed = JSON.parse(body); } catch {}
+      if (parsed) capturedMutations.push({ body: parsed });
+      const sent = parsed?.variables?.data ?? {};
+      const merged = { ...KIT_BASE, ...sent, subStatus: { ...subStatus, ...(sent.subStatus || {}) } };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { updateKit: merged } }),
+      });
+      return;
+    }
+    if (body.includes('autoCompleteDonors') || body.includes('autoCompleteDeviceRequests')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { donorsConnection: { content: [] }, deviceRequestsConnection: { content: [] } } }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: {} }) });
+  });
+}
+
+test('Save on invalid form: surfaces an error toast and does not fire updateKit', async ({ page }) => {
+  test.setTimeout(60_000);
+  const captured: { body: any }[] = [];
+  await installGraphqlMocks(page, SUBSTATUS_EMPTY_NETWORK, captured);
+
+  await page.goto('/dashboard/devices/20031');
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  // The form is invalid (subStatus.network is required for SMARTPHONE and unset).
+  // Pre-fix: button is disabled, the click is a no-op, no toast appears.
+  // Post-fix: the click runs updateEntity which surfaces a toast and aborts the mutation.
+  await page.locator('button:has-text("Save")').first().click({ force: true });
+  await page.waitForTimeout(1500);
+
+  // Toast must be visible with copy that names the missing-fields condition.
+  const toast = page.locator('.toast-error, [role="alert"]').filter({ hasText: /required fields/i }).first();
+  await expect(toast, 'an error toast should explain that required fields are incomplete').toBeVisible({ timeout: 5_000 });
+
+  expect(captured.length, 'updateKit must NOT fire when the form is invalid').toBe(0);
+});
+
+test('Save on valid form: still fires updateKit', async ({ page }) => {
+  test.setTimeout(60_000);
+  const captured: { body: any }[] = [];
+  await installGraphqlMocks(page, SUBSTATUS_WITH_NETWORK, captured);
+
+  await page.goto('/dashboard/devices/20031');
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  await page.locator('button:has-text("Save")').first().click();
+  await page.waitForTimeout(1500);
+
+  expect(captured.length, 'updateKit should fire on a valid form').toBeGreaterThan(0);
+});

--- a/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
@@ -924,6 +924,20 @@ export class KitInfoComponent {
     return this.form.getRawValue();
   }
 
+  private collectInvalidFieldLabels(fields: FormlyFieldConfig[] = [], out: string[] = []): string[] {
+    for (const f of fields) {
+      if (f.fieldGroup && f.fieldGroup.length) {
+        this.collectInvalidFieldLabels(f.fieldGroup, out);
+        continue;
+      }
+      const control = f.formControl;
+      if (!control || control.valid || control.disabled) continue;
+      const label = (f.templateOptions?.label as string) || (f.key as string) || '';
+      if (label && !out.includes(label)) out.push(label);
+    }
+    return out;
+  }
+
   private queryRef = this.apollo
     .watchQuery({
       query: QUERY_ENTITY,
@@ -1122,7 +1136,15 @@ export class KitInfoComponent {
   }
 
   updateEntity(data: any) {
-    console.log(this.form.invalid);
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      const missing = this.collectInvalidFieldLabels(this.fields);
+      const body = missing.length
+        ? `<small>Required fields are incomplete: ${missing.join(', ')}</small>`
+        : `<small>Required fields are incomplete. Please review the highlighted fields above.</small>`;
+      this.toastr.error(body, 'Cannot save', { enableHtml: true });
+      return;
+    }
     data.id = this.entityId;
 
     // we set the value of content to a blank string if it is null so as to not create issues in the back

--- a/src/app/views/corewidgets/components/kit-info/kit-info.html
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.html
@@ -28,8 +28,9 @@
                   </h6>
                 </div>
                 <div>
-                  <button [disabled]="form.invalid" (click)="updateEntity(getFormData())"
-                    type="submit" class="btn btn-primary btn-sm">
+                  <button [class.btn-warning]="form.invalid" [class.btn-primary]="!form.invalid"
+                    (click)="updateEntity(getFormData())"
+                    type="submit" class="btn btn-sm">
                     <small>Save</small>
                   </button>
                 </div>
@@ -41,8 +42,9 @@
                   <formly-form [options]="options" (ngSubmit)="form.valid && updateEntity(getFormData())"
                     [form]="form" [model]="model" [fields]="fields">
                   </formly-form>
-                  <button style="width: 150px" [disabled]="form.invalid" (click)="updateEntity(getFormData())"
-                    type="submit" class="btn btn-info btn-sm p-2">
+                  <button style="width: 150px" (click)="updateEntity(getFormData())"
+                    type="submit" class="btn btn-sm p-2"
+                    [class.btn-info]="!form.invalid" [class.btn-warning]="form.invalid">
                     <small>Save</small>
                   </button>
                 }


### PR DESCRIPTION
Fixes #49.

## Root cause
Both Save buttons in `src/app/views/corewidgets/components/kit-info/kit-info.html` were bound to `[disabled]="form.invalid"`. When a required field — most commonly `subStatus.network` on a SMARTPHONE/COMMSDEVICE — was empty, the button was silently disabled and the click became a no-op. There was no toast, no field highlight, and the volunteer who reported this on device 20031 / request 6526 was left with "the button does not appear to work."

## Fix
- `kit-info.html` — Save buttons are no longer `[disabled]`. They switch to `btn-warning` colour when the form is invalid as a visual cue, but remain clickable.
- `kit-info.component.ts` — `updateEntity()` now bails out at the top if `form.invalid`: it calls `form.markAllAsTouched()` (so Formly renders error styling on every required field at once), walks the Formly field tree to collect the labels of every invalid control, and shows an error toast:

  > **Cannot save** — Required fields are incomplete: Network provider?, …

- The `updateKit` GraphQL mutation does **not** fire on an invalid form.

## Test plan
- New spec `e2e/tests/kit-required-field-feedback.spec.ts` (red before this change, green after):
  - **Save on invalid form** — loads a SMARTPHONE kit with `subStatus.network = null`, clicks Save, asserts an error toast appears and that no `updateKit` mutation is captured.
  - **Save on valid form** — loads the same kit with `subStatus.network = 'UNLOCKED'`, clicks Save, asserts `updateKit` fires.
- The existing `kit-locked-status` suite still passes (no regression on the adjacent flows).
- `ng build --configuration production` completes cleanly.

## Notes for reviewers
- The change is scoped to the device-edit (kit-info) form only. Other forms in the app may have the same `[disabled]="form.invalid"` pattern — worth a follow-up sweep if you agree with this approach.
- This is the first PR generated by the automated issue-triage workflow described in `CLAUDE.md`; please flag anything you'd want done differently for the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)