### PR TITLE
Sweep: extract warnIfFormInvalid helper, apply to other edit forms

### DIFF
--- a/e2e/tests/save-button-clickable.spec.ts
+++ b/e2e/tests/save-button-clickable.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Sweep regression: the Save button on edit forms must remain clickable so that
+ * `warnIfFormInvalid` can surface a toast instead of the button silently being
+ * disabled. Issue #49 was kit-info specifically; this covers the same fix
+ * applied to device-request-info and post-info.
+ *
+ * The full toast-on-invalid behaviour is covered by
+ * kit-required-field-feedback.spec.ts — this smoke test only verifies that the
+ * `[disabled]="form.invalid"` binding has been removed across the swept forms.
+ */
+import { test, expect } from '@playwright/test';
+
+async function fulfillSimple(route: import('@playwright/test').Route, data: any) {
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ data }),
+  });
+}
+
+test('device-request-info: Save button is clickable, not [disabled]', async ({ page }) => {
+  test.setTimeout(60_000);
+
+  await page.route('**/graphql', async route => {
+    const body = route.request().postData() ?? '';
+    if (body.includes('buildInfo')) {
+      return fulfillSimple(route, { buildInfo: { version: '1.0.0-test', commit: 'abc', time: '2026-01-01T00:00:00Z' } });
+    }
+    if (body.includes('findDeviceRequest')) {
+      return fulfillSimple(route, {
+        deviceRequest: {
+          id: 6526,
+          status: 'NEW',
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+          collectionDate: null,
+          collectionMethod: null,
+          collectionContactName: null,
+          deviceRequestItems: { phones: 0, tablets: 0, laptops: 0, allInOnes: 0, desktops: 0, commsDevices: 0, other: 0, broadbandHubs: 0 },
+          referringOrganisationContact: null,
+          isSales: false,
+          isPrepped: false,
+          clientRef: 'REF-1',
+          details: '',
+          borough: '',
+          kits: [],
+          deviceRequestNeeds: { hasInternet: false, hasMobilityIssues: false, needQuickStart: false },
+          deviceRequestNotes: [],
+        },
+      });
+    }
+    if (body.includes('countDevicesForRequest')) {
+      return fulfillSimple(route, { kitsConnection: { totalElements: 0 } });
+    }
+    return fulfillSimple(route, {});
+  });
+
+  await page.goto('/dashboard/device-requests/6526');
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  const saveBtn = page.locator('button:has-text("Save")').first();
+  await expect(saveBtn).toBeVisible();
+  // After the fix, `[disabled]` is no longer bound. The button must not carry a
+  // `disabled` attribute regardless of form state.
+  await expect(saveBtn).not.toHaveAttribute('disabled', /.*/);
+});
+
+test('post-info: Save button is clickable, not [disabled]', async ({ page }) => {
+  test.setTimeout(60_000);
+
+  await page.route('**/graphql', async route => {
+    const body = route.request().postData() ?? '';
+    if (body.includes('buildInfo')) {
+      return fulfillSimple(route, { buildInfo: { version: '1.0.0-test', commit: 'abc', time: '2026-01-01T00:00:00Z' } });
+    }
+    if (body.includes('findPost')) {
+      return fulfillSimple(route, {
+        post: {
+          id: 1,
+          title: 'Test post',
+          slug: 'test-post',
+          secured: false,
+          content: 'Body',
+          published: false,
+          createdAt: '2025-01-01T00:00:00Z',
+          updatedAt: '2025-01-01T00:00:00Z',
+        },
+      });
+    }
+    return fulfillSimple(route, {});
+  });
+
+  await page.goto('/dashboard/posts/1');
+  // post-info has two tabs: "Post" (default) and "Edit" (form). Switch to Edit.
+  await page.locator('a[ngbNavLink]:has-text("Edit")').click();
+  await page.locator('formly-form').waitFor({ state: 'visible', timeout: 30_000 });
+  await page.waitForTimeout(2000);
+
+  const saveBtn = page.locator('button:has-text("Save")').first();
+  await expect(saveBtn).toBeVisible();
+  await expect(saveBtn).not.toHaveAttribute('disabled', /.*/);
+});

--- a/src/app/shared/utils/form-validation.ts
+++ b/src/app/shared/utils/form-validation.ts
@@ -1,0 +1,36 @@
+import { UntypedFormGroup } from '@angular/forms';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { ToastrService } from 'ngx-toastr';
+
+function collectInvalidFieldLabels(fields: FormlyFieldConfig[] = [], out: string[] = []): string[] {
+  for (const f of fields) {
+    if (f.fieldGroup && f.fieldGroup.length) {
+      collectInvalidFieldLabels(f.fieldGroup, out);
+      continue;
+    }
+    const control = f.formControl;
+    if (!control || control.valid || control.disabled) continue;
+    const label = (f.templateOptions?.label as string) || (f.key as string) || '';
+    if (label && !out.includes(label)) out.push(label);
+  }
+  return out;
+}
+
+// Returns true if the form was invalid (caller should bail), false if it was valid.
+// On invalid: marks all controls touched (so Formly surfaces per-field errors), collects
+// the labels of every invalid field, and shows an error toast naming them.
+export function warnIfFormInvalid(
+  form: UntypedFormGroup,
+  fields: FormlyFieldConfig[],
+  toastr: ToastrService,
+  title = 'Cannot save',
+): boolean {
+  if (!form.invalid) return false;
+  form.markAllAsTouched();
+  const missing = collectInvalidFieldLabels(fields);
+  const body = missing.length
+    ? `<small>Required fields are incomplete: ${missing.join(', ')}</small>`
+    : `<small>Required fields are incomplete. Please review the highlighted fields above.</small>`;
+  toastr.error(body, title, { enableHtml: true });
+  return true;
+}

--- a/src/app/shared/utils/index.ts
+++ b/src/app/shared/utils/index.ts
@@ -2,3 +2,4 @@ export { HashUtils, Token } from './hash_utils';
 export { DateUtils } from './date_utils';
 export { DEVICE_TYPES, DEVICE_TYPE_LOOKUP, getDeviceTypeLabel, KIT_TYPES, getKitTypeLabel } from './device-types';
 export type { DeviceType } from './device-types';
+export { warnIfFormInvalid } from './form-validation';

--- a/src/app/views/corewidgets/components/admin-panel/admin-panel.component.html
+++ b/src/app/views/corewidgets/components/admin-panel/admin-panel.component.html
@@ -22,8 +22,9 @@
             </h6>
           </div>
           <div>
-            <button [disabled]="form.invalid" (click)="updateConfig(form.value)"
-              type="submit" class="btn btn-primary btn-sm">
+            <button (click)="updateConfig(form.value)"
+              type="submit" class="btn btn-sm"
+              [class.btn-primary]="!form.invalid" [class.btn-warning]="form.invalid">
               <small>Save Configuration</small>
             </button>
           </div>

--- a/src/app/views/corewidgets/components/admin-panel/admin-panel.component.ts
+++ b/src/app/views/corewidgets/components/admin-panel/admin-panel.component.ts
@@ -12,6 +12,7 @@ import { UserState } from '@app/state/state.module';
 import { User } from '@app/state/user/user.state';
 import { Title } from '@angular/platform-browser';
 import { DatePipe } from '@angular/common';
+import { warnIfFormInvalid } from '@app/shared/utils';
 
 const QUERY_CONFIG = gql`
   query adminConfig {
@@ -224,10 +225,7 @@ export class AdminPanelComponent {
   }
 
   updateConfig(data: any) {
-    if (!this.form.valid) {
-      this.model['showErrorState'] = true;
-      return;
-    }
+    if (warnIfFormInvalid(this.form, this.fields, this.toastr, 'Cannot save configuration')) return;
 
     this.apollo
       .mutate({

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
@@ -45,8 +45,9 @@
                       {{ generatingPdf ? 'Generating...' : 'Generate PDF' }}
                     </small>
                   </button>
-                  <button [disabled]="form.invalid" (click)="updateEntity(form.value)"
-                    type="submit" class="btn btn-primary btn-sm">
+                  <button (click)="updateEntity(form.value)"
+                    type="submit" class="btn btn-sm"
+                    [class.btn-primary]="!form.invalid" [class.btn-warning]="form.invalid">
                     <small>Save</small>
                   </button>
                 </div>

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -12,7 +12,7 @@ import { Select } from '@ngxs/store';
 import { UserState } from '@app/state/state.module';
 import { User } from '@app/state/user/user.state';
 import { Title } from '@angular/platform-browser';
-import { getKitTypeLabel } from '@app/shared/utils';
+import { getKitTypeLabel, warnIfFormInvalid } from '@app/shared/utils';
 
 import { KitComponent } from '../kit-component/kit-component.component';
 import { DeviceRequestAuditComponent } from '../device-request-audit-component/device-request-audit-component.component';
@@ -928,11 +928,7 @@ export class DeviceRequestInfoComponent {
   }
 
   updateEntity(data: any) {
-
-    if (!this.form.valid) {
-      this.model['showErrorState'] = true;
-      return;
-    }
+    if (warnIfFormInvalid(this.form, this.fields, this.toastr)) return;
     data.id = this.requestId;
 
     if (data.deviceRequestNote.content == null){

--- a/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
+++ b/src/app/views/corewidgets/components/kit-info/kit-info.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { Subject, of, forkJoin, Observable, Subscription, concat, from } from 'rxjs';
 import { AppGridDirective } from '@app/shared/modules/grid/app-grid.directive';
-import { KIT_TYPES } from '@app/shared/utils';
+import { KIT_TYPES, warnIfFormInvalid } from '@app/shared/utils';
 import { NgbModal, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLink, NgbNavLinkBase, NgbNavContent, NgbNavOutlet } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
 import gql from 'graphql-tag';
@@ -924,20 +924,6 @@ export class KitInfoComponent {
     return this.form.getRawValue();
   }
 
-  private collectInvalidFieldLabels(fields: FormlyFieldConfig[] = [], out: string[] = []): string[] {
-    for (const f of fields) {
-      if (f.fieldGroup && f.fieldGroup.length) {
-        this.collectInvalidFieldLabels(f.fieldGroup, out);
-        continue;
-      }
-      const control = f.formControl;
-      if (!control || control.valid || control.disabled) continue;
-      const label = (f.templateOptions?.label as string) || (f.key as string) || '';
-      if (label && !out.includes(label)) out.push(label);
-    }
-    return out;
-  }
-
   private queryRef = this.apollo
     .watchQuery({
       query: QUERY_ENTITY,
@@ -1136,15 +1122,7 @@ export class KitInfoComponent {
   }
 
   updateEntity(data: any) {
-    if (this.form.invalid) {
-      this.form.markAllAsTouched();
-      const missing = this.collectInvalidFieldLabels(this.fields);
-      const body = missing.length
-        ? `<small>Required fields are incomplete: ${missing.join(', ')}</small>`
-        : `<small>Required fields are incomplete. Please review the highlighted fields above.</small>`;
-      this.toastr.error(body, 'Cannot save', { enableHtml: true });
-      return;
-    }
+    if (warnIfFormInvalid(this.form, this.fields, this.toastr)) return;
     data.id = this.entityId;
 
     // we set the value of content to a blank string if it is null so as to not create issues in the back

--- a/src/app/views/corewidgets/components/post-info/post-info.component.ts
+++ b/src/app/views/corewidgets/components/post-info/post-info.component.ts
@@ -8,6 +8,7 @@ import { Apollo } from 'apollo-angular';
 import { UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormlyFormOptions, FormlyFieldConfig, FormlyModule } from '@ngx-formly/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { warnIfFormInvalid } from '@app/shared/utils';
 
 const QUERY_ENTITY = gql`
 query findPost($id: Long!) {
@@ -194,6 +195,7 @@ export class PostInfoComponent {
   }
 
   updateEntity(data: any) {
+    if (warnIfFormInvalid(this.form, this.fields, this.toastr)) return;
     data.id = this.entityId;
     this.apollo.mutate({
       mutation: UPDATE_ENTITY,

--- a/src/app/views/corewidgets/components/post-info/post-info.html
+++ b/src/app/views/corewidgets/components/post-info/post-info.html
@@ -40,8 +40,9 @@
                                 <formly-form [options]="options" (ngSubmit)="form.valid && updateEntity(form.value)"
                                     [form]="form" [model]="model" [fields]="fields">
                                 </formly-form>
-                                <button style="width: 150px" [disabled]="form.invalid" (click)="updateEntity(form.value)"
-                                    type="submit" class="btn btn-info btn-sm p-2">
+                                <button style="width: 150px" (click)="updateEntity(form.value)"
+                                    type="submit" class="btn btn-sm p-2"
+                                    [class.btn-info]="!form.invalid" [class.btn-warning]="form.invalid">
                                     <small>Save</small>
                                 </button>
                             </form>


### PR DESCRIPTION
Follow-up to #50. Stacked on top of `claude/issue-49-required-field-feedback`, so once #50 merges this PR auto-rebases against `dev`.

## What this adds
- New helper `src/app/shared/utils/form-validation.ts` → `warnIfFormInvalid(form, fields, toastr, title?)`. Returns `true` if the form is invalid (caller should bail), and as a side-effect:
  1. calls `form.markAllAsTouched()` so Formly surfaces per-field error styling everywhere at once,
  2. walks the Formly field tree to collect the labels of every invalid control,
  3. shows a `toastr.error` with copy like *"Required fields are incomplete: Network provider?, Borough, …"*
- Refactor `kit-info.component.ts` to use the shared helper instead of the inline copy introduced in #50.
- Apply the same fix to:
  - `device-request-info` — also removes the dead `model['showErrorState'] = true` early-return (the flag was set but never read anywhere).
  - `post-info`
  - `admin-panel` (`updateConfig`)
- Each Save button:
  - removes `[disabled]="form.invalid"` so the click reaches the handler,
  - swaps to `btn-warning` when invalid as a secondary visual cue.

## Scope notes
Modal **CREATE** / **Filter** / **ASSIGN** buttons across ~14 index components still use the same `[disabled]="form.invalid"` pattern. They are deliberately left alone in this PR because the form fields are colocated inside the modal — the greyed-out button is right next to the missing field, so the silent-click UX is much less acute. If reviewers agree the toast-on-invalid pattern is the right one across the board, happy to do a third sweep.

## Test plan
- `e2e/tests/save-button-clickable.spec.ts` (new) — asserts the Save button on `device-request-info` and `post-info` is rendered without a `disabled` attribute. Failed before this PR (where `[disabled]="form.invalid"` was bound), passes after.
- `e2e/tests/kit-required-field-feedback.spec.ts` (from #50) — full red/green for the helper end-to-end via kit-info.
- `e2e/tests/kit-locked-status.spec.ts` — 4/4 still green; the kit-info refactor didn't disturb the locked-status flow.
- `ng build --configuration production` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)