### PR TITLE
docs: add CHANGELOG.md and Release Workflow rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+`master` tracks the latest state deployed to production. A new versioned
+section is cut from `[Unreleased]` each time `master` advances after a
+successful production deploy (see "Release Workflow" in `CLAUDE.md`).
+
+## [Unreleased]
+
+### Added
+- Issue Triage Workflow documented in `CLAUDE.md` for automated bug-issue handling
+- E2E regression test `DEVREQ-B1` for device-type toggle Formly flush
+- E2E regression tests for the May bug batch
+- Week-button calendar on D&D now shows current week + 3 upcoming
+
+### Changed
+- Sweep edit forms to use the same required-field feedback pattern as kit-info
+- Production SWA deploy is now triggered manually and built from `dev`
+- Loading bar and spinner recoloured from amber to sidebar blue
+- Age column hidden from device tables
+- Inline-critical CSS optimisation disabled in production build
+- D&D week filter now shows all statuses
+
+### Fixed
+- kit-info surfaces required-field feedback when Save clicked on an invalid form
+- Public device-request form: silent submit failure when 3-request limit hit; error toast cleanup
+- Numeric inline-edit values coerced to `Int` before save
+- kit-info: untick stays disabled and Save sends `type=null` (#48)
+- kit-status radio buttons: missing left padding (#45)
+- `subStatus` flags no longer scrubbed on hide-state transitions
+- Startup interstitial delayed by 1s grace window to avoid flicker
+- kit form render deferred until kit data has loaded; patched after load so stored flags survive Formly's stale controls
+- Nested kit fields deep-copied so Formly can write defaults
+- Show/hide toggle preserves `id` through safeHtml sanitisation
+- Three latent `hideExpression` bugs found in the sweep
+- `hideExpression` toggles that never flushed
+- Find Email: not-found prompt now appears for unknown emails
+- Four bugs fixed in the public device-request form
+- Swapped totals in the device-request filter info label
+- Devices/requests not loading inside related records
+- UAT website bug XMAB-B (#46)
+
+[Unreleased]: https://github.com/CommunityTechaid/techaid-dashboard/compare/master...dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,44 @@ Auth is configured in `src/app/shared/services/authentication.service.ts`. The A
 
 Environment configs live in `src/environments/` (dev, prod, uat, local).
 
+## Release Workflow
+
+`master` represents the latest state deployed to production — it is not the
+default development branch. Versioning and the changelog hang off this rule.
+
+1. Work merges into `dev` via PR. `dev` auto-deploys to UAT and patch-bumps
+   `package.json` (see `.github/workflows/deploy-dev.yml`).
+2. Each PR that produces a user-visible change must add a bullet under
+   `## [Unreleased]` in `CHANGELOG.md`, grouped under
+   `Added` / `Changed` / `Fixed` / `Removed` / `Security`. Pure refactors,
+   test-only changes, and CI tweaks don't need an entry.
+3. Production deploys are manual: run the `Deploy to Production SWA`
+   workflow (`workflow_dispatch`) — it builds and deploys from `dev`.
+4. **After a successful production deploy**, fast-forward `master` to the
+   deployed commit and push:
+   ```bash
+   git fetch origin
+   git checkout master
+   git merge --ff-only origin/dev
+   git push origin master
+   ```
+   If a fast-forward isn't possible, stop and investigate — `master`
+   should never diverge from `dev`'s history.
+5. Then cut the release: read the current `package.json` version (e.g.
+   `1.0.27`), rename `## [Unreleased]` in `CHANGELOG.md` to
+   `## [1.0.27] — YYYY-MM-DD`, add a fresh empty `## [Unreleased]` above
+   it, commit to `master`, tag (`git tag v1.0.27 && git push origin v1.0.27`),
+   and create a GitHub Release for the tag using that changelog section
+   as the body.
+
+Safety rails:
+- Never push to `master` other than the fast-forward described above.
+- Never tag `dev` commits — tags belong on `master` so they always point
+  at production state.
+- If `dev` has multiple version bumps between prod deploys, the release
+  takes whatever version is on `master` after the fast-forward — that's
+  the version that actually shipped.
+
 ## Testing
 
 Run the full e2e suite against the UAT backend (requires a valid token in `e2e/.auth/user.json`):


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, seeded with an `[Unreleased]` section reconstructed from recent `dev` history (grouped Added / Changed / Fixed).
- Adds a **Release Workflow** section to `CLAUDE.md` that codifies the convention requested by staff:
  - `master` represents the latest state deployed to production — not a development branch.
  - After a successful production deploy (`Deploy to Production SWA` workflow), fast-forward `master` from `dev` and push.
  - Each user-visible PR adds a bullet under `## [Unreleased]`.
  - When `master` advances, promote `[Unreleased]` to a versioned section, tag `master` with `vX.Y.Z`, and create a GitHub Release using that section as the body.

No code changes; no behavioural changes to the dev or prod deploy workflows. This is a manual-first changelog process — a follow-up will evaluate folding in [`release-please`](https://github.com/googleapis/release-please) to automate version bumps and release-PR creation (Option B: target `dev`, delete the existing `npm version patch` step in `deploy-dev.yml`, let the release PR be the explicit "ready to ship" gate).

## Test plan

- [ ] Skim `CHANGELOG.md` for any miscategorised or missed items from recent `dev` history
- [ ] Confirm the Release Workflow steps in `CLAUDE.md` match how the team actually wants to cut releases (especially the fast-forward-only invariant and the tag-from-`master` rule)
- [ ] No CI impact expected (docs-only)

https://claude.ai/code/session_01KMzJhTnn7xkHKv9dRHzhUH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMzJhTnn7xkHKv9dRHzhUH)_