### PR TITLE
fix: clone Apollo response nested objects in device-request-info

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -744,7 +744,7 @@ export class DeviceRequestInfoComponent {
   }
 
   private normalizeData(data: any) {
-    data = { ...data }; // Apollo v3 freezes query results in dev mode; copy before mutating
+    data = structuredClone(data); // Apollo v4 deep-freezes query/mutation responses; deep-clone before Formly writes to nested objects
 
     this.newNoteField.templateOptions['requestId'] = this.requestId
 


### PR DESCRIPTION
## Summary

Replace the shallow `{ ...data }` spread in `normalizeData` with `structuredClone(data)` so nested objects in the Apollo response (`deviceRequestItems`, `deviceRequestNeeds`, `referringOrganisationContact`, each element of `deviceRequestNotes`) are mutable copies rather than the original frozen Apollo v4 references.

Also updates the stale "Apollo v3" comment to reflect Apollo v4.

## Root cause

Apollo Client v4 deep-freezes every node of every query/mutation response. The previous shallow spread freed only the top-level object, leaving each nested object frozen. On `/dashboard/device-requests/{id}`, ngx-formly's `assignModelValue` / `assignFieldValue` write into `model.deviceRequestItems.phones` et al. and hit the freeze, throwing 8 `TypeError: Cannot assign to read only property` errors on every page load (one per field — phones, tablets, laptops, allInOnes, desktops, commsDevices, broadbandHubs, other).

The page renders correctly visually because Formly silently swallows the throw, but the writes are no-ops and the errors are loud in the console. Same family of bug as 9c36e27, #38, #39.

## Test plan

- [x] `ng build --configuration production` — passes cleanly.
- [x] Verified `/dashboard/device-requests/3171` previously logged 8 console errors during page load; confirmed via Playwright investigation on UAT.
- [ ] Reviewer manual check: load any `/dashboard/device-requests/{id}` after this PR is deployed to UAT and confirm zero `Cannot assign to read only property` errors in the browser console.

No automated regression test added — the bug is silent in the rendered output, and the issue was triaged as a follow-up cleanup of a known class of bug rather than a `bug`-labelled triage ticket. Visible regressions in this area are already covered by BUG-08 / BUG-09 / BUG-19 / BUG-20 in `e2e/tests/bugs.spec.ts`.