### PR TITLE
fix: send pagination sort direction as String in user tables (#72)

### DIFF
--- a/e2e/tests/issue-72-user-index-sort.spec.ts
+++ b/e2e/tests/issue-72-user-index-sort.spec.ts
@@ -5,18 +5,20 @@ import { resolve } from 'path';
 /**
  * Regression test for issue #72 — "Unable to view 'users' in tada".
  *
- * Every server-side paginated table sends a `$page: PaginationInput` variable whose
- * `sort` is a list of `{ key, value }` pairs. The server types `sort[].value` as a
- * String ("asc" / "desc"). user-index (and role-users) were sending it as an integer
- * (`(o.dir == 'asc') ? 1 : -1`), so GraphQL rejected the whole variable with:
+ * The Users tables build a `$page: PaginationInput` whose `sort` is a list of
+ * `{ key, value }` pairs. The `users` resolver validates the combined `key:value`
+ * string against the pattern `^field:(1|-1)$` AND requires `value` to be a String.
+ * user-index (and role-users) sent `value` as the integer `1`/`-1`, so GraphQL
+ * rejected the whole variable with:
  *
  *   Variable 'page' has an invalid value: Expected a String input, but it was a 'Integer'
  *
- * Both tables declare a default sort (user-index order [3,'desc'], role-users [0,'desc']),
- * so the bad sort goes out on the very first load and the table never renders.
+ * The fix sends the string `'1'`/`'-1'` (NOT `"asc"`/`"desc"` — the users resolver
+ * rejects those with a pattern error, unlike the other tables' resolvers).
  *
- * Before the fix these tests fail: the findAllUsers response carries the Integer error
- * and no data rows render. After the fix (value: o.dir) the query succeeds.
+ * user-index declares a default sort (order [3,'desc']), so the bad value goes out
+ * on the very first load and the table never renders. Before the fix this test fails
+ * (a users-query GraphQL error is captured and no rows render); after it passes.
  */
 
 function getBearerToken(): string {
@@ -33,27 +35,16 @@ function getBearerToken(): string {
   throw new Error('No Auth0 token found in e2e/.auth/user.json — run: node e2e/save-token.mjs');
 }
 
-/** True if a GraphQL errors[] payload contains the integer-sort type error. */
-function hasIntegerSortError(bodyText: string): boolean {
-  try {
-    const json = JSON.parse(bodyText);
-    return (json.errors ?? []).some((e: any) =>
-      /invalid value: Expected a String input, but it was a 'Integer'/i.test(e?.message ?? '')
-    );
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Routes /graphql to UAT with a bearer token (mirrors the other specs) and records
- * whether any findAllUsers response carried the integer-sort error.
+ * the first GraphQL error returned by any users query (operation name contains
+ * "findAllUsers", which covers both user-index and the role-users table query).
  */
 async function withAuthAndErrorCapture(
   page: import('@playwright/test').Page,
-): Promise<{ sawIntegerError: () => boolean }> {
+): Promise<{ usersQueryError: () => string | null }> {
   const token = getBearerToken();
-  let integerError = false;
+  let firstError: string | null = null;
 
   await page.route('**/graphql', async route => {
     try {
@@ -69,8 +60,12 @@ async function withAuthAndErrorCapture(
         },
       });
       const bodyText = await response.text();
-      if (postData.includes('findAllUsers') && hasIntegerSortError(bodyText)) {
-        integerError = true;
+      if (postData.includes('findAllUsers') && firstError === null) {
+        try {
+          const json = JSON.parse(bodyText);
+          const err = (json.errors ?? [])[0]?.message;
+          if (err) firstError = err;
+        } catch { /* non-JSON body */ }
       }
       await route.fulfill({ response, body: bodyText });
     } catch {
@@ -78,39 +73,31 @@ async function withAuthAndErrorCapture(
     }
   });
 
-  return { sawIntegerError: () => integerError };
+  return { usersQueryError: () => firstError };
 }
 
-test.describe("Issue #72 — users table sort value must be a String", () => {
+test.describe("Issue #72 — users table sort value must be the string '1'/'-1'", () => {
   test.afterEach(async ({ page }) => {
     await page.unrouteAll({ behavior: 'ignoreErrors' });
   });
 
-  test('user-index loads without the Integer-sort GraphQL error', async ({ page }) => {
+  test('user-index loads and renders rows without a users-query GraphQL error', async ({ page }) => {
     const capture = await withAuthAndErrorCapture(page);
     await page.goto('/dashboard/users');
 
-    // Table element renders regardless; the bug is that the ajax query errors.
     await expect(page.locator('table#user-index')).toBeVisible({ timeout: 20_000 });
 
-    // The data rows only appear if findAllUsers succeeded. Before the fix this never
-    // resolves and the integer error is captured below.
+    // UAT has users, so rows MUST render once the sorted query succeeds. Before the
+    // fix the query errors, entities stay empty and no row links ever appear.
     const dataRow = page.locator('table#user-index tbody tr td a[href*="/dashboard/users/"]');
-    const rowsAppeared = await dataRow.first().waitFor({ state: 'visible', timeout: 20_000 })
-      .then(() => true)
-      .catch(() => false);
+    await expect(dataRow.first()).toBeVisible({ timeout: 20_000 });
 
-    expect(capture.sawIntegerError(),
-      "findAllUsers returned the integer-sort error — sort[].value was sent as an Integer").toBe(false);
-
-    if (!rowsAppeared) {
-      test.skip(true, 'No users in UAT database — no rows to assert, but the query did not error');
-      return;
-    }
-    await expect(dataRow.first()).toBeVisible();
+    expect(capture.usersQueryError(),
+      'findAllUsers returned a GraphQL error — sort[].value was not the expected String "1"/"-1"')
+      .toBeNull();
   });
 
-  test('role-users tab loads without the Integer-sort GraphQL error', async ({ page }) => {
+  test('role-users tab loads without a users-query GraphQL error', async ({ page }) => {
     const capture = await withAuthAndErrorCapture(page);
     await page.goto('/dashboard/roles');
 
@@ -125,21 +112,18 @@ test.describe("Issue #72 — users table sort value must be a String", () => {
 
     await page.goto((await roleLink.first().getAttribute('href'))!);
 
-    const usersTab = page.locator('ul.nav-tabs .nav-link', { hasText: /^\s*users\s*$/i });
-    const tabVisible = await usersTab.first().waitFor({ state: 'visible', timeout: 15_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!tabVisible) {
-      test.skip(true, 'No Users tab on the role page — structure may have changed');
-      return;
-    }
+    // role-info renders the Users tab via ngbNav (<a ngbNavLink>Users</a>).
+    const usersTab = page.locator('.nav-tabs .nav-link', { hasText: /^\s*users\s*$/i });
+    await expect(usersTab.first()).toBeVisible({ timeout: 15_000 });
     await usersTab.first().click();
 
-    // Give the tab's DataTable ajax a moment to fire and resolve.
-    await expect(page.locator('table[id*="user"], table.dataTable')).toBeVisible({ timeout: 15_000 });
+    // Let the tab's DataTable ajax fire and resolve (role may have 0 users, so we
+    // assert on the absence of an error rather than on rows).
+    await expect(page.locator('table[id*="user"], table.dataTable').first()).toBeVisible({ timeout: 15_000 });
     await page.waitForTimeout(2_000);
 
-    expect(capture.sawIntegerError(),
-      'role-users findAllUsers returned the integer-sort error — sort[].value was sent as an Integer').toBe(false);
+    expect(capture.usersQueryError(),
+      'role-users users query returned a GraphQL error — sort[].value was not the expected String "1"/"-1"')
+      .toBeNull();
   });
 });

--- a/e2e/tests/issue-72-user-index-sort.spec.ts
+++ b/e2e/tests/issue-72-user-index-sort.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression test for issue #72 — "Unable to view 'users' in tada".
+ *
+ * Every server-side paginated table sends a `$page: PaginationInput` variable whose
+ * `sort` is a list of `{ key, value }` pairs. The server types `sort[].value` as a
+ * String ("asc" / "desc"). user-index (and role-users) were sending it as an integer
+ * (`(o.dir == 'asc') ? 1 : -1`), so GraphQL rejected the whole variable with:
+ *
+ *   Variable 'page' has an invalid value: Expected a String input, but it was a 'Integer'
+ *
+ * Both tables declare a default sort (user-index order [3,'desc'], role-users [0,'desc']),
+ * so the bad sort goes out on the very first load and the table never renders.
+ *
+ * Before the fix these tests fail: the findAllUsers response carries the Integer error
+ * and no data rows render. After the fix (value: o.dir) the query succeeds.
+ */
+
+function getBearerToken(): string {
+  const statePath = resolve(process.cwd(), 'e2e/.auth/user.json');
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  for (const origin of state.origins ?? []) {
+    for (const item of origin.localStorage ?? []) {
+      if (item.name.startsWith('@@auth0spajs@@')) {
+        const parsed = JSON.parse(item.value);
+        return parsed?.body?.access_token ?? '';
+      }
+    }
+  }
+  throw new Error('No Auth0 token found in e2e/.auth/user.json — run: node e2e/save-token.mjs');
+}
+
+/** True if a GraphQL errors[] payload contains the integer-sort type error. */
+function hasIntegerSortError(bodyText: string): boolean {
+  try {
+    const json = JSON.parse(bodyText);
+    return (json.errors ?? []).some((e: any) =>
+      /invalid value: Expected a String input, but it was a 'Integer'/i.test(e?.message ?? '')
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Routes /graphql to UAT with a bearer token (mirrors the other specs) and records
+ * whether any findAllUsers response carried the integer-sort error.
+ */
+async function withAuthAndErrorCapture(
+  page: import('@playwright/test').Page,
+): Promise<{ sawIntegerError: () => boolean }> {
+  const token = getBearerToken();
+  let integerError = false;
+
+  await page.route('**/graphql', async route => {
+    try {
+      const postData = route.request().postData() ?? '';
+      const { origin, 'sec-fetch-site': _a, 'sec-fetch-mode': _b, 'sec-fetch-dest': _c, ...safeHeaders } =
+        route.request().headers();
+      const response = await route.fetch({
+        url: 'https://api-testing.communitytechaid.org.uk/graphql',
+        headers: {
+          ...safeHeaders,
+          'Authorization': `Bearer ${token}`,
+          'host': 'api-testing.communitytechaid.org.uk',
+        },
+      });
+      const bodyText = await response.text();
+      if (postData.includes('findAllUsers') && hasIntegerSortError(bodyText)) {
+        integerError = true;
+      }
+      await route.fulfill({ response, body: bodyText });
+    } catch {
+      // Context may have closed while an in-flight background GraphQL request was pending.
+    }
+  });
+
+  return { sawIntegerError: () => integerError };
+}
+
+test.describe("Issue #72 — users table sort value must be a String", () => {
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('user-index loads without the Integer-sort GraphQL error', async ({ page }) => {
+    const capture = await withAuthAndErrorCapture(page);
+    await page.goto('/dashboard/users');
+
+    // Table element renders regardless; the bug is that the ajax query errors.
+    await expect(page.locator('table#user-index')).toBeVisible({ timeout: 20_000 });
+
+    // The data rows only appear if findAllUsers succeeded. Before the fix this never
+    // resolves and the integer error is captured below.
+    const dataRow = page.locator('table#user-index tbody tr td a[href*="/dashboard/users/"]');
+    const rowsAppeared = await dataRow.first().waitFor({ state: 'visible', timeout: 20_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    expect(capture.sawIntegerError(),
+      "findAllUsers returned the integer-sort error — sort[].value was sent as an Integer").toBe(false);
+
+    if (!rowsAppeared) {
+      test.skip(true, 'No users in UAT database — no rows to assert, but the query did not error');
+      return;
+    }
+    await expect(dataRow.first()).toBeVisible();
+  });
+
+  test('role-users tab loads without the Integer-sort GraphQL error', async ({ page }) => {
+    const capture = await withAuthAndErrorCapture(page);
+    await page.goto('/dashboard/roles');
+
+    const roleLink = page.locator('table tbody tr td a[href*="/dashboard/roles/"]');
+    const roleAppeared = await roleLink.first().waitFor({ state: 'visible', timeout: 20_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!roleAppeared) {
+      test.skip(true, 'No roles in UAT database — cannot exercise the role-users tab');
+      return;
+    }
+
+    await page.goto((await roleLink.first().getAttribute('href'))!);
+
+    const usersTab = page.locator('ul.nav-tabs .nav-link', { hasText: /^\s*users\s*$/i });
+    const tabVisible = await usersTab.first().waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!tabVisible) {
+      test.skip(true, 'No Users tab on the role page — structure may have changed');
+      return;
+    }
+    await usersTab.first().click();
+
+    // Give the tab's DataTable ajax a moment to fire and resolve.
+    await expect(page.locator('table[id*="user"], table.dataTable')).toBeVisible({ timeout: 15_000 });
+    await page.waitForTimeout(2_000);
+
+    expect(capture.sawIntegerError(),
+      'role-users findAllUsers returned the integer-sort error — sort[].value was sent as an Integer').toBe(false);
+  });
+});

--- a/src/app/views/corewidgets/components/role-users/role-users.component.ts
+++ b/src/app/views/corewidgets/components/role-users/role-users.component.ts
@@ -230,7 +230,7 @@ export class RoleUsersComponent {
         const sort = params.order.map(o => {
           return {
             key: this.dtOptions.columns[o.column].data,
-            value: o.dir
+            value: (o.dir == 'asc') ? '1' : '-1'
           };
         });
 

--- a/src/app/views/corewidgets/components/role-users/role-users.component.ts
+++ b/src/app/views/corewidgets/components/role-users/role-users.component.ts
@@ -230,7 +230,7 @@ export class RoleUsersComponent {
         const sort = params.order.map(o => {
           return {
             key: this.dtOptions.columns[o.column].data,
-            value: (o.dir == 'asc') ? 1 : -1
+            value: o.dir
           };
         });
 

--- a/src/app/views/corewidgets/components/user-index/user-index.component.ts
+++ b/src/app/views/corewidgets/components/user-index/user-index.component.ts
@@ -118,7 +118,7 @@ export class UserIndexComponent {
         const sort = params.order.map(o => {
           return {
             key: sorted[`${this.dtOptions.columns[o.column].data}`],
-            value: o.dir
+            value: (o.dir == 'asc') ? '1' : '-1'
           };
         });
 

--- a/src/app/views/corewidgets/components/user-index/user-index.component.ts
+++ b/src/app/views/corewidgets/components/user-index/user-index.component.ts
@@ -118,7 +118,7 @@ export class UserIndexComponent {
         const sort = params.order.map(o => {
           return {
             key: sorted[`${this.dtOptions.columns[o.column].data}`],
-            value: (o.dir == 'asc') ? 1 : -1
+            value: o.dir
           };
         });
 


### PR DESCRIPTION
Fixes #72

## Root cause

The Users tables build a `$page: PaginationInput` whose `sort` is a list of `{ key, value }` pairs. The `users` resolver validates the combined `key:value` string against `^field:(1|-1)$` **and** requires `value` to be a String. user-index sent `value` as the **integer** `1`/`-1`:

```ts
// user-index.component.ts (before)
value: (o.dir == 'asc') ? 1 : -1
```

Because user-index declares a default sort (`order: [3, 'desc']`), that bad value goes out on the **very first load**, so GraphQL rejects the entire `page` variable before any rows render:

> `Variable 'page' has an invalid value: Expected a String input, but it was a 'Integer'`

That's the exact error in the report, and why the Users table is unusable every time it's opened.

## Fix

Quote the value so it's sent as the string `'1'`/`'-1'`, keeping the ordering semantics the resolver expects:

```ts
value: (o.dir == 'asc') ? '1' : '-1'
```

⚠️ **Note for reviewers:** an earlier revision of this PR changed it to `value: o.dir` (`"asc"`/`"desc"`) — the form every *other* table uses. Live UAT testing caught that the `users` resolver is **inconsistent** with the rest of the API and rejects `"asc"`/`"desc"` with a pattern error. The string `'1'`/`'-1'` is the correct value for this resolver. No schema/API change made here, but the backend sort-format inconsistency is worth a separate look.

The identical integer code existed in `role-users.component.ts` (Role → Users tab) and is changed the same way for consistency. Empirically that table never actually emits a sort (both columns are `orderable: false`), so it was latent rather than broken — its regression test passes even with the old integer code.

## Test plan

New spec `e2e/tests/issue-72-user-index-sort.spec.ts` (2 tests) routes `/graphql` to UAT and captures any users-query GraphQL error:
- `user-index loads and renders rows without a users-query GraphQL error` — asserts data rows render **and** no users-query error is returned.
- `role-users tab loads without a users-query GraphQL error`.

**Verified red/green against UAT** (55 users in the testing DB):
- ✅ Green (string `'1'`/`'-1'`): `2 passed` — user-index renders rows.
- ✅ Red (original integer `1`/`-1`): user-index test **fails** — query errors, no rows render.
- ✅ `ng build --configuration production` — clean (14.4s).

Awaiting human review — will not self-merge. Note `Fixes #72` won't auto-close on a `dev` merge (default branch is `master`), so #72 needs a manual close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)