### PR TITLE
fix: guard user/role detail tabs against null nested relationships

### DIFF
--- a/e2e/tests/detail-null-relationships.spec.ts
+++ b/e2e/tests/detail-null-relationships.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Regression test: user/role detail tabs must not crash when the back-end returns
+ * null for the nested relationship fields.
+ *
+ * The back-end currently resolves `user(id).roles`, `user(id).permissions`,
+ * `role(id).users` and `role(id).permissions` to null (no GraphQL error — the field
+ * just comes back null). The DataTables ajax callbacks dereferenced that directly
+ * (`data = res.data.user.roles; data['totalElements']`), throwing
+ * `TypeError: Cannot read properties of null (reading 'totalElements')`, so the tab
+ * hung forever on "Loading…".
+ *
+ * This test forces those nested fields to null in the GraphQL response (so it
+ * reproduces the crash deterministically even after the back-end is fixed), then
+ * asserts the tabs render without the null-deref TypeError. Before the front-end
+ * guard it fails; after it passes.
+ */
+
+function getToken(): string {
+  const s = JSON.parse(readFileSync(resolve(process.cwd(), 'e2e/.auth/user.json'), 'utf8'));
+  for (const o of s.origins ?? []) for (const i of o.localStorage ?? [])
+    if (i.name.startsWith('@@auth0spajs@@')) return JSON.parse(i.value)?.body?.access_token ?? '';
+  throw new Error('No Auth0 token found in e2e/.auth/user.json — run: node e2e/save-token.mjs');
+}
+
+/** Route /graphql to UAT, force nested relationship fields to null, and collect null-deref errors. */
+async function setup(page: import('@playwright/test').Page): Promise<{ nullDerefErrors: () => string[] }> {
+  const token = getToken();
+  const errors: string[] = [];
+  const isNullDeref = (t: string) => /Cannot read properties of null|Cannot read property .* of null/.test(t);
+  page.on('pageerror', e => { if (isNullDeref(`${e.message}`)) errors.push(`pageerror: ${e.message}`); });
+  page.on('console', m => { if (m.type() === 'error' && isNullDeref(m.text())) errors.push(`console: ${m.text()}`); });
+
+  await page.route('**/graphql', async route => {
+    try {
+      const { origin, 'sec-fetch-site': _a, 'sec-fetch-mode': _b, 'sec-fetch-dest': _c, ...h } = route.request().headers();
+      const resp = await route.fetch({
+        url: 'https://api-testing.communitytechaid.org.uk/graphql',
+        headers: { ...h, Authorization: `Bearer ${token}`, host: 'api-testing.communitytechaid.org.uk' },
+      });
+      let body = await resp.text();
+      try {
+        const j = JSON.parse(body);
+        let changed = false;
+        if (j?.data?.user) for (const k of ['roles', 'permissions']) if (k in j.data.user) { j.data.user[k] = null; changed = true; }
+        if (j?.data?.role) for (const k of ['users', 'permissions']) if (k in j.data.role) { j.data.role[k] = null; changed = true; }
+        if (changed) body = JSON.stringify(j);
+      } catch { /* non-JSON */ }
+      await route.fulfill({ response: resp, body });
+    } catch { /* context closed mid-flight */ }
+  });
+
+  return { nullDerefErrors: () => errors };
+}
+
+/** Fetch a real userId and roleId straight from the GraphQL API (robust vs. UI scraping). */
+async function fetchIds(): Promise<{ uid: string | null; rid: string | null }> {
+  const token = getToken();
+  const q = async (query: string, variables: any) => {
+    const r = await fetch('https://api-testing.communitytechaid.org.uk/graphql', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    });
+    return r.json() as any;
+  };
+  const page = { size: 1, page: 0, sort: [] as any[] };
+  const u = await q('query($p:PaginationInput!,$t:String){ users(page:$p,filter:$t){ items{ userId } } }', { p: page, t: '' });
+  const r = await q('query($p:PaginationInput!,$t:String){ roles(page:$p,filter:$t){ items{ id } } }', { p: page, t: '' });
+  return { uid: u?.data?.users?.items?.[0]?.userId ?? null, rid: r?.data?.roles?.items?.[0]?.id ?? null };
+}
+
+test.describe('Detail pages survive null nested relationships', () => {
+  test.afterEach(async ({ page }) => { await page.unrouteAll({ behavior: 'ignoreErrors' }); });
+
+  test('user detail: Roles and Permissions tabs do not crash on null', async ({ page }) => {
+    const cap = await setup(page);
+    const { uid } = await fetchIds();
+    if (!uid) { test.skip(true, 'No users in UAT'); return; }
+
+    await page.goto(`/dashboard/users/${uid}`);
+    // Roles tab is the default; then switch to Permissions.
+    await expect(page.locator('.nav-tabs .nav-link', { hasText: /roles/i }).first()).toBeVisible({ timeout: 15_000 });
+    await page.locator('.nav-tabs .nav-link', { hasText: /permissions/i }).first().click();
+    await page.waitForTimeout(3_000);
+
+    expect(cap.nullDerefErrors(), 'user detail tabs threw a null-deref on null relationships').toEqual([]);
+  });
+
+  test('role detail: Users and Permissions tabs do not crash on null', async ({ page }) => {
+    const cap = await setup(page);
+    const { rid } = await fetchIds();
+    if (!rid) { test.skip(true, 'No roles in UAT'); return; }
+
+    await page.goto(`/dashboard/roles/${rid}`);
+    await expect(page.locator('.nav-tabs .nav-link', { hasText: /users/i }).first()).toBeVisible({ timeout: 15_000 });
+    await page.locator('.nav-tabs .nav-link', { hasText: /permissions/i }).first().click();
+    await page.waitForTimeout(3_000);
+
+    expect(cap.nullDerefErrors(), 'role detail tabs threw a null-deref on null relationships').toEqual([]);
+  });
+});

--- a/src/app/views/corewidgets/components/role-permissions/role-permissions.component.ts
+++ b/src/app/views/corewidgets/components/role-permissions/role-permissions.component.ts
@@ -162,7 +162,7 @@ export class RolePermissionsComponent {
         queryRef.refetch(vars).then(res => {
           let data: any = {};
           if (res && res.data) {
-            data = res['data']['role']['permissions'];
+            data = res['data']?.['role']?.['permissions'] || { totalElements: 0, content: [] };
             if (!this.total) {
               this.total = data['totalElements'];
             }

--- a/src/app/views/corewidgets/components/role-users/role-users.component.ts
+++ b/src/app/views/corewidgets/components/role-users/role-users.component.ts
@@ -247,7 +247,7 @@ export class RoleUsersComponent {
         queryRef.refetch(vars).then(res => {
           let data: any = {};
           if (res && res.data) {
-            data = res['data']['role']['users'];
+            data = res['data']?.['role']?.['users'] || { totalElements: 0, content: [] };
             if (!this.total) {
               this.total = data['totalElements'];
             }

--- a/src/app/views/corewidgets/components/user-permissions/user-permissions.component.ts
+++ b/src/app/views/corewidgets/components/user-permissions/user-permissions.component.ts
@@ -309,13 +309,13 @@ export class UserPermissionsComponent {
         queryRef.refetch(vars).then(res => {
           let data: any = {};
           if (res && res.data) {
-            data = res['data']['user']['permissions'];
+            data = res['data']?.['user']?.['permissions'] || { totalElements: 0, content: [] };
             if (!this.total) {
               this.total = data['totalElements'];
             }
             const roles = {};
-            res['data']['user']['roles']['content'].forEach(r => {
-              r['permissions']['items'].forEach(p => {
+            (res['data']?.['user']?.['roles']?.['content'] || []).forEach(r => {
+              (r?.['permissions']?.['items'] || []).forEach(p => {
                 roles[p.name] = roles[p.name] || [];
                 roles[p.name].push(r.name);
               });

--- a/src/app/views/corewidgets/components/user-roles/user-roles.component.ts
+++ b/src/app/views/corewidgets/components/user-roles/user-roles.component.ts
@@ -236,7 +236,7 @@ export class UserRolesComponent {
         queryRef.refetch(vars).then(res => {
           let data: any = {};
           if (res.data) {
-            data = res['data']['user']['roles'];
+            data = res['data']?.['user']?.['roles'] || { totalElements: 0, content: [] };
             if (!this.total) {
               this.total = data['totalElements'];
             }


### PR DESCRIPTION
## Problem

Drilling into a **user** or a **role** leaves the detail tabs stuck on "Loading…" forever. Root cause is split across two layers:

**Back-end (the actual data loss — not fixed here):** the nested relationship fields resolve to `null` with no GraphQL error:
- `user(id).roles` → null
- `user(id).permissions` → null
- `role(id).users` → null
- `role(id).permissions` → null

Verified against UAT for an account that definitely has the data (my own admin user, who holds the ADMINISTRATOR role, and the ADMINISTRATOR role which contains me). This is a back-end resolver regression (likely the Auth0 Management API integration) and lives in **techaid-server**, not this repo.

**Front-end (fixed here):** the four DataTables ajax callbacks dereferenced the nested object directly:

```ts
data = res['data']['user']['roles'];   // null
this.total = data['totalElements'];    // TypeError: Cannot read properties of null
```

Because the callback throws, DataTables never gets its response and the tab hangs on "Loading…" with a silent console crash.

## Fix

Guard all four callbacks to fall back to `{ totalElements: 0, content: [] }` when the nested field is null, plus user-permissions' secondary `user.roles.content` forEach:

- `user-roles.component.ts`
- `role-users.component.ts`
- `user-permissions.component.ts` (two spots)
- `role-permissions.component.ts`

The tabs now render a clean empty table instead of crashing. **This does not restore the missing roles/users/permissions** — that needs the back-end fix.

## Test plan

New spec `e2e/tests/detail-null-relationships.spec.ts` forces the nested fields to `null` in the GraphQL response (so it reproduces the crash deterministically even once the back-end is fixed) and asserts the detail tabs don't throw the null-deref.

- ✅ Green (with guards): `2 passed` against UAT.
- ✅ Red (guards stashed out): `2 failed` — `null-deref on null relationships`.
- ✅ `ng build --configuration production` — clean (15s).

## Follow-up

Back-end ticket needed in techaid-server: restore `User.roles` / `Role.users` / `*.permissions` resolvers (check the Auth0 Management API call/credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)