### PR TITLE
fix: redirect to login on expired session instead of Access Denied popup

### DIFF
--- a/src/app/graphql.module.ts
+++ b/src/app/graphql.module.ts
@@ -5,26 +5,59 @@ import { HttpLink } from 'apollo-angular/http';
 import { ApolloClientOptions, InMemoryCache } from '@apollo/client/core';
 import { setContext } from '@apollo/client/link/context';
 import { onError } from '@apollo/client/link/error';
+import { ServerError } from '@apollo/client/errors';
 import { ConfigService } from '@app/shared/services/config.service';
 import { AuthenticationService } from './shared/services/authentication.service';
 
+// Auth0 error codes that mean the session is genuinely gone and the user must log in again
+// (as opposed to a transient/network failure, where bouncing them to Auth0 would be wrong).
+const REAUTH_ERROR_CODES = ['login_required', 'consent_required', 'missing_refresh_token'];
 
 export function createApollo(httpLink: HttpLink, config: ConfigService, authService: AuthenticationService): ApolloClientOptions {
   const http = httpLink.create({
     uri: config.environment.graphql_endpoint
   });
 
+  // A burst of failed queries (e.g. several tables loading at once) can each detect the auth
+  // failure; guard so only the first triggers the redirect to Auth0 and we never loop.
+  let reauthInProgress = false;
+  const redirectToLogin = () => {
+    if (reauthInProgress) {
+      return;
+    }
+    reauthInProgress = true;
+    // Preserve the current route so the user returns here after logging in — same mechanism
+    // the AuthGuard uses (login(state.url)).
+    authService.login(window.location.pathname + window.location.search);
+  };
+
   const asyncAuthLink = setContext((_request, _previous) => new Promise((success) => {
     authService.getTokenSilently$({ audience: config.environment.auth_audience }).subscribe(
       token => {
         success({ headers: new HttpHeaders({ 'Authorization': `Bearer ${token}` }) });
       },
-      () => success({})
+      (err) => {
+        // The Auth0 session has expired: send the user to log in again rather than firing an
+        // unauthenticated request, which the API rejects as a confusing "Access Denied".
+        if (err && REAUTH_ERROR_CODES.includes(err.error)) {
+          redirectToLogin();
+        }
+        success({});
+      }
     );
   }));
 
-  const errorHandler = onError(_options => {
-    // network errors are handled silently — lists will be empty without the API
+  const errorHandler = onError(({ error }) => {
+    // A 401 from the API means the token is missing/expired → prompt re-login. A GraphQL-level
+    // "Access Denied" (HTTP 200, surfaced as a CombinedGraphQLErrors with no statusCode) is
+    // deliberately left alone: it can be a genuine permission denial for an authenticated user,
+    // and redirecting on it would cause a login loop.
+    const status = ServerError.is(error)
+      ? error.statusCode
+      : ((error as any)?.statusCode ?? (error as any)?.status);
+    if (status === 401) {
+      redirectToLogin();
+    }
   });
 
   return {

--- a/src/app/shared/modules/grid/app-grid.directive.ts
+++ b/src/app/shared/modules/grid/app-grid.directive.ts
@@ -6,6 +6,11 @@ import 'datatables.net-bs5';
 import 'datatables.net-rowreorder';
 import 'datatables.net-responsive';
 
+// Suppress DataTables' default blocking browser-alert on an ajax failure. Errors are already
+// surfaced via toastr by the table components; the alert was the source of the confusing
+// "Access Denied" popup when a request went out unauthenticated (e.g. during an API restart).
+($.fn.dataTable as any).ext.errMode = 'none';
+
 @Directive({ selector: '[datatable]' })
 export class AppGridDirective implements OnDestroy, OnInit {
   /**


### PR DESCRIPTION
## Why

When the Auth0 session expires (or a request goes out unauthenticated during an API restart/deploy), users got a confusing **"Access Denied" popup** in data tables instead of being asked to log back in. Root causes:

1. `graphql.module.ts`'s `onError` link was a **no-op** — nothing detected auth failures.
2. The auth link **swallowed token failures** (`() => success({})`), sending the request with *no* `Authorization` header. The API then returned `Access Denied`, which surfaced in the table.
3. DataTables' default `errMode` turns an ajax error into a **blocking browser `alert()`** — the "weird popup."

(We saw exactly this in production App Insights during the recent API restart: `findAll`/`findAllDonors` → `[DataFetchingException] Access Denied` at HTTP 200, i.e. token-less requests.)

## What

- **Redirect to login on genuine session expiry** (`graphql.module.ts`):
  - In the auth link, if `getAccessTokenSilently()` fails with an Auth0 re-auth code (`login_required` / `consent_required` / `missing_refresh_token`), redirect via the existing `AuthenticationService.login(currentRoute)` — preserving the current route (same mechanism `AuthGuard` uses), so the user lands back where they were.
  - In `onError`, also redirect on a **401** network error (`ServerError.is(error) && statusCode === 401`, with a duck-typed fallback for however apollo-angular wraps it).
  - **Loop-safe:** a `reauthInProgress` guard ensures a burst of failed table queries triggers only one redirect.
  - **Deliberately untouched:** a GraphQL-level `Access Denied` at HTTP 200 (a `CombinedGraphQLErrors`, no status code) is *not* treated as a login problem — it can be a genuine permission denial for an authenticated user, and redirecting would loop.

- **Remove the scary popup** (`app-grid.directive.ts`): set `$.fn.dataTable.ext.errMode = 'none'` globally so a failed ajax no longer pops a blocking browser alert. Table components already surface errors via toastr, so messaging is preserved — just non-blocking.

## Test plan

- `ng build --configuration production` passes (the stricter correctness signal in this repo).
- Auth-expiry is hard to reproduce in an automated e2e (needs a dead Auth0 session), so this was verified by build + a manual reasoning pass over the link order and the loop guard. Behaviour for a healthy token is unchanged; only the failure paths differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
