### PR TITLE
fix: allow operators to clear a collection/delivery booking on device requests (#42)

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
@@ -58,6 +58,14 @@
                 <formly-form [options]="options" (ngSubmit)="updateEntity(form.value)"
                   [form]="form" [model]="model" [fields]="fields">
                 </formly-form>
+                @if (model?.collectionDate) {
+                  <div class="mt-2">
+                    <button type="button" class="btn btn-outline-secondary btn-sm"
+                      (click)="clearCollectionDate()">
+                      <small><i class="fas fa-times"></i> Clear Collection/Delivery Date</small>
+                    </button>
+                  </div>
+                }
                 <!-- <button *ngIf="!options.formState.disabled" style="width: 150px" (click)="updateEntity(form.value)"
                 type="submit" class="btn btn-primary btn-sm p-2">
                 <small>Save</small>

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -927,6 +927,11 @@ export class DeviceRequestInfoComponent {
     }
   }
 
+  clearCollectionDate() {
+    this.form.patchValue({ collectionDate: null });
+    this.model = { ...this.model, collectionDate: null };
+  }
+
   updateEntity(data: any) {
     if (warnIfFormInvalid(this.form, this.fields, this.toastr)) return;
     data.id = this.requestId;

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -934,10 +934,11 @@ export class DeviceRequestInfoComponent {
     if (data.deviceRequestNote.content == null){
       data.deviceRequestNote.content = ""
     }
-    // Convert collectionDate from datetime-local (local time) back to UTC ISO string for the server
-    if (data.collectionDate) {
-      data.collectionDate = new Date(data.collectionDate).toISOString();
-    }
+    // Convert collectionDate from datetime-local (local time) back to UTC ISO string for the server.
+    // If the field was cleared, send null so the server removes the booking.
+    data.collectionDate = data.collectionDate
+      ? new Date(data.collectionDate).toISOString()
+      : null;
     this.apollo
       .mutate({
         mutation: UPDATE_ENTITY,


### PR DESCRIPTION
## Summary

- Fixes the save-side bug where clearing the `collectionDate` field sent nothing to the server (empty string is falsy, so the old date was silently retained). Now sends `null` explicitly so the server removes the booking.
- Adds a **"Clear Collection/Delivery Date"** button beneath the device request form, visible only when a date is currently set. Clicking it clears the field immediately; the next Save persists the removal.

## Root cause

`updateEntity` had `if (data.collectionDate) { ... }` — a falsy guard that meant a cleared datetime-local input (value `""`) never reached the server as `null`. The booking date was never actually removed.

## Test plan

- Open a device request that has a collection/delivery date set
- Confirm the "Clear Collection/Delivery Date" button is visible below the form
- Click it — the date field should go blank
- Click Save — confirm the date is gone after reload and the request no longer appears in that week's D&D view
- Confirm the button is absent on requests with no date set

Fixes #42

https://claude.ai/code/session_01JiVda2AVFgn2jwwoF7xSnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiVda2AVFgn2jwwoF7xSnS)_