### PR TITLE
fix: move clear-date button inline with field and auto-save on click (#42)

### DIFF
--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.html
@@ -58,14 +58,6 @@
                 <formly-form [options]="options" (ngSubmit)="updateEntity(form.value)"
                   [form]="form" [model]="model" [fields]="fields">
                 </formly-form>
-                @if (model?.collectionDate) {
-                  <div class="mt-2">
-                    <button type="button" class="btn btn-outline-secondary btn-sm"
-                      (click)="clearCollectionDate()">
-                      <small><i class="fas fa-times"></i> Clear Collection/Delivery Date</small>
-                    </button>
-                  </div>
-                }
                 <!-- <button *ngIf="!options.formState.disabled" style="width: 150px" (click)="updateEntity(form.value)"
                 type="submit" class="btn btn-primary btn-sm p-2">
                 <small>Save</small>

--- a/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
+++ b/src/app/views/corewidgets/components/device-request-info/device-request-info.component.ts
@@ -692,6 +692,13 @@ export class DeviceRequestInfoComponent {
               }
             },
             {
+              template: `<button type="button" class="btn btn-outline-secondary btn-sm mb-3" id="clearCollectionDateBtn">
+                <small><i class="fas fa-times"></i> Clear date</small>
+              </button>`,
+              templateOptions: { safeHtml: true },
+              hideExpression: (model: any) => !model.collectionDate,
+            },
+            {
               key: 'collectionMethod',
               type: 'radio',
               className: '',
@@ -900,10 +907,12 @@ export class DeviceRequestInfoComponent {
     // Set up global click handler for toggle button using event delegation
     this.clickHandler = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
-      const button = target.closest('#toggleDeviceTypesBtn');
-      if (button) {
+      if (target.closest('#toggleDeviceTypesBtn')) {
         e.preventDefault();
         this.toggleDeviceTypes();
+      } else if (target.closest('#clearCollectionDateBtn')) {
+        e.preventDefault();
+        this.clearCollectionDate();
       }
     };
     document.addEventListener('click', this.clickHandler);
@@ -930,6 +939,8 @@ export class DeviceRequestInfoComponent {
   clearCollectionDate() {
     this.form.patchValue({ collectionDate: null });
     this.model = { ...this.model, collectionDate: null };
+    this.options = { ...this.options };
+    this.updateEntity(this.form.value);
   }
 
   updateEntity(data: any) {


### PR DESCRIPTION
## Summary

Follow-up to the earlier fix. The previous "Clear Collection/Delivery Date" button was appended at the bottom of the card body — easy to miss and required a separate Save click to persist.

- Button is now a formly field rendered directly below the date input in column 3, only visible when a date is set
- Uses the same event-delegation pattern already in place for the show/hide device types toggle
- Clicking "Clear date" immediately saves — no separate Save click needed

## Test plan

- Open a device request with a collection/delivery date set
- Confirm a small "× Clear date" button appears directly beneath the date field
- Click it — the field clears and the success toast fires automatically
- Reload the page and confirm the date is gone
- Confirm no clear button appears on requests without a date set

Refs #42

https://claude.ai/code/session_01JiVda2AVFgn2jwwoF7xSnS

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiVda2AVFgn2jwwoF7xSnS)_