### PR TITLE
ci: drive Projects v2 board Status field from issue + deploy workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -56,10 +56,17 @@ jobs:
           app_location: dist
           skip_app_build: true
 
-      - name: Label linked issues as in-uat
+      - name: Promote linked issues to "In UAT" (label + project board)
         uses: actions/github-script@v7
         with:
+          # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in
+          # GITHUB_TOKEN cannot write org-level Projects v2, so a PAT is required.
+          github-token: ${{ secrets.PROJECTS_PAT }}
           script: |
+            // "TaDa Kanban" (project #2) Status single-select — see workflow docs.
+            const PROJECT_ID = 'PVT_kwDOB1-IbM4BZvoG';
+            const STATUS_FIELD = 'PVTSSF_lADOB1-IbM4BZvoGzhUsLjg';
+            const OPTION_IN_UAT = '47fc9ee4';
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -69,17 +76,29 @@ jobs:
             for (const pr of mergedPRs) {
               const refs = [...(pr.body || '').matchAll(/(?:fixes|closes|resolves)\s+#(\d+)/gi)];
               for (const [, num] of refs) {
-                console.log(`PR #${pr.number} → issue #${num}: status: in-uat`);
+                const issue_number = parseInt(num);
+                console.log(`PR #${pr.number} → issue #${issue_number}: In UAT`);
+                // 1) Labels (kept as a parallel, filterable signal)
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner, repo: context.repo.repo,
-                  issue_number: parseInt(num), labels: ['status: in-uat'],
+                  issue_number, labels: ['status: in-uat'],
                 });
                 try {
                   await github.rest.issues.removeLabel({
                     owner: context.repo.owner, repo: context.repo.repo,
-                    issue_number: parseInt(num), name: 'status: backlog',
+                    issue_number, name: 'status: backlog',
                   });
                 } catch { /* label may not be present */ }
+                // 2) Project board Status field → In UAT
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number,
+                });
+                const added = await github.graphql(
+                  `mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`,
+                  { p: PROJECT_ID, c: issue.node_id });
+                await github.graphql(
+                  `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+                  { p: PROJECT_ID, i: added.addProjectV2ItemById.item.id, f: STATUS_FIELD, o: OPTION_IN_UAT });
               }
             }
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -57,6 +57,7 @@ jobs:
           skip_app_build: true
 
       - name: Promote linked issues to "In UAT" (label + project board)
+        continue-on-error: true   # board sync must never fail the deploy
         uses: actions/github-script@v7
         with:
           # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -67,6 +67,7 @@ jobs:
           GITHUB_SHA: ${{ github.sha }}
 
       - name: Label linked issues as shipped
+        continue-on-error: true   # board sync must never block the master fast-forward
         uses: actions/github-script@v7
         with:
           # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -69,8 +69,15 @@ jobs:
       - name: Label linked issues as shipped
         uses: actions/github-script@v7
         with:
+          # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in
+          # GITHUB_TOKEN cannot write org-level Projects v2, so a PAT is required.
+          github-token: ${{ secrets.PROJECTS_PAT }}
           script: |
             const { execSync } = require('child_process');
+            // "TaDa Kanban" (project #2) Status single-select — see workflow docs.
+            const PROJECT_ID = 'PVT_kwDOB1-IbM4BZvoG';
+            const STATUS_FIELD = 'PVTSSF_lADOB1-IbM4BZvoGzhUsLjg';
+            const OPTION_ON_LIVE_SITE = '98236657';
             // Find the previous prod deploy tag to bound the commit range
             const tags = execSync('git tag --list "deploy/prod/*" --sort=-creatordate')
               .toString().trim().split('\n').filter(Boolean);
@@ -93,17 +100,29 @@ jobs:
                 seen.add(pr.number);
                 const refs = [...(pr.body || '').matchAll(/(?:fixes|closes|resolves)\s+#(\d+)/gi)];
                 for (const [, num] of refs) {
-                  console.log(`PR #${pr.number} → issue #${num}: status: shipped`);
+                  const issue_number = parseInt(num);
+                  console.log(`PR #${pr.number} → issue #${issue_number}: status: shipped`);
+                  // 1) Labels (kept as a parallel, filterable signal)
                   await github.rest.issues.addLabels({
                     owner: context.repo.owner, repo: context.repo.repo,
-                    issue_number: parseInt(num), labels: ['status: shipped'],
+                    issue_number, labels: ['status: shipped'],
                   });
                   try {
                     await github.rest.issues.removeLabel({
                       owner: context.repo.owner, repo: context.repo.repo,
-                      issue_number: parseInt(num), name: 'status: in-uat',
+                      issue_number, name: 'status: in-uat',
                     });
                   } catch { /* label may not be present */ }
+                  // 2) Project board Status field → On Live Site
+                  const { data: issue } = await github.rest.issues.get({
+                    owner: context.repo.owner, repo: context.repo.repo, issue_number,
+                  });
+                  const added = await github.graphql(
+                    `mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`,
+                    { p: PROJECT_ID, c: issue.node_id });
+                  await github.graphql(
+                    `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+                    { p: PROJECT_ID, i: added.addProjectV2ItemById.item.id, f: STATUS_FIELD, o: OPTION_ON_LIVE_SITE });
                 }
               }
             }

--- a/.github/workflows/issue-backfill-backlog.yml
+++ b/.github/workflows/issue-backfill-backlog.yml
@@ -14,6 +14,7 @@ jobs:
 
     steps:
       - name: Label unlabeled open issues as backlog
+        continue-on-error: true   # board sync must never fail the workflow
         uses: actions/github-script@v7
         with:
           # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in

--- a/.github/workflows/issue-backfill-backlog.yml
+++ b/.github/workflows/issue-backfill-backlog.yml
@@ -16,7 +16,14 @@ jobs:
       - name: Label unlabeled open issues as backlog
         uses: actions/github-script@v7
         with:
+          # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in
+          # GITHUB_TOKEN cannot write org-level Projects v2, so a PAT is required.
+          github-token: ${{ secrets.PROJECTS_PAT }}
           script: |
+            // "TaDa Kanban" (project #2) Status single-select — see workflow docs.
+            const PROJECT_ID = 'PVT_kwDOB1-IbM4BZvoG';
+            const STATUS_FIELD = 'PVTSSF_lADOB1-IbM4BZvoGzhUsLjg';
+            const OPTION_BACKLOG = 'f75ad846';
             let page = 1;
             let labelled = 0;
             while (true) {
@@ -33,12 +40,21 @@ jobs:
                 const hasStatus = issue.labels.some(l => l.name.startsWith('status:'));
                 if (!hasStatus) {
                   console.log(`Labelling issue #${issue.number}: ${issue.title}`);
+                  // 1) Labels (kept as a parallel, filterable signal)
                   await github.rest.issues.addLabels({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
                     labels: ['status: backlog'],
                   });
+                  // 2) Project board Status field → Backlog
+                  // node_id is available directly on each issue list response object.
+                  const added = await github.graphql(
+                    `mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`,
+                    { p: PROJECT_ID, c: issue.node_id });
+                  await github.graphql(
+                    `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+                    { p: PROJECT_ID, i: added.addProjectV2ItemById.item.id, f: STATUS_FIELD, o: OPTION_BACKLOG });
                   labelled++;
                 }
               }

--- a/.github/workflows/issue-label-backlog.yml
+++ b/.github/workflows/issue-label-backlog.yml
@@ -12,6 +12,7 @@ jobs:
 
     steps:
       - name: Apply backlog label
+        continue-on-error: true   # board sync must never fail the workflow
         uses: actions/github-script@v7
         with:
           # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in

--- a/.github/workflows/issue-label-backlog.yml
+++ b/.github/workflows/issue-label-backlog.yml
@@ -14,10 +14,27 @@ jobs:
       - name: Apply backlog label
         uses: actions/github-script@v7
         with:
+          # PROJECTS_PAT: classic PAT (project + repo scopes). The built-in
+          # GITHUB_TOKEN cannot write org-level Projects v2, so a PAT is required.
+          github-token: ${{ secrets.PROJECTS_PAT }}
           script: |
+            // "TaDa Kanban" (project #2) Status single-select — see workflow docs.
+            const PROJECT_ID = 'PVT_kwDOB1-IbM4BZvoG';
+            const STATUS_FIELD = 'PVTSSF_lADOB1-IbM4BZvoGzhUsLjg';
+            const OPTION_BACKLOG = 'f75ad846';
+            // 1) Labels (kept as a parallel, filterable signal)
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
               labels: ['status: backlog'],
             });
+            // 2) Project board Status field → Backlog
+            // node_id is available directly from the webhook payload — no REST call needed.
+            const contentId = context.payload.issue.node_id;
+            const added = await github.graphql(
+              `mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}`,
+              { p: PROJECT_ID, c: contentId });
+            await github.graphql(
+              `mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}`,
+              { p: PROJECT_ID, i: added.addProjectV2ItemById.item.id, f: STATUS_FIELD, o: OPTION_BACKLOG });


### PR DESCRIPTION
## Summary

Completes the GitHub Projects v2 board automation started in #83. The four status workflows now update the **"TaDa Kanban"** board's built-in `Status` single-select field directly via GraphQL — driving a real Backlog → In UAT → On Live Site Kanban — alongside the existing `status:` labels (kept as a parallel, filterable signal).

| Workflow | Trigger | Board action |
|---|---|---|
| `issue-label-backlog.yml` | issue opened | add to board, Status = **Backlog** |
| `issue-backfill-backlog.yml` | manual | same, for existing unlabelled open issues |
| `deploy-dev.yml` | successful UAT deploy | linked issues → **In UAT** |
| `deploy-prod.yml` | successful prod deploy | linked issues → **On Live Site** |

Each step resolves the issue node ID, calls `addProjectV2ItemById` (idempotent), then `updateProjectV2ItemFieldValue` to set the option.

## Token

Project mutations use a new repo secret **`PROJECTS_PAT`** (classic PAT, `project` + `repo` scopes) passed as `github-token:` to `actions/github-script` — the built-in `GITHUB_TOKEN` cannot write org-level Projects v2. Secret is set.

## Safety

All board/label steps are `continue-on-error: true` so a missing/expired PAT or a transient Projects API error can never fail a deploy — in particular it can't block `deploy-prod`'s subsequent **master fast-forward**.

## Verified

Seeded live against the real board to prove the IDs/mutations: issues **#82** and **#52** were added and set to **In UAT** successfully; the 14 open backlog issues sit in **Backlog**.

## Test plan

- [ ] Merge → no functional app change (CI-only)
- [ ] Open a test issue → appears in **Backlog** column
- [ ] Next UAT deploy → a linked issue moves to **In UAT**
- [ ] Next prod deploy → a linked issue moves to **On Live Site**

🤖 Generated with [Claude Code](https://claude.com/claude-code)