### PR TITLE
fix: show System for automated audit revisions (#56)

### DIFF
--- a/e2e/tests/audit-system-label.spec.ts
+++ b/e2e/tests/audit-system-label.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Audit "Who" column — System label for automated revisions.
+ *
+ * This spec needs a UAT-enabled environment to reach the kit detail page
+ * (sandbox host allowlist blocks api-testing.communitytechaid.org.uk, so it
+ * cannot run here); it is red-before / green-after by design — before the fix
+ * the Who cell is blank for customUser "|", after it shows "System".
+ *
+ * The getAuditTrail GraphQL response is stubbed so the assertion does not depend
+ * on whether UAT happens to have an automated revision.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function getBearerToken(): string {
+  const statePath = resolve(process.cwd(), 'e2e/.auth/user.json');
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  for (const origin of state.origins ?? []) {
+    for (const item of origin.localStorage ?? []) {
+      if (item.name.startsWith('@@auth0spajs@@')) {
+        const parsed = JSON.parse(item.value);
+        return parsed?.body?.access_token ?? '';
+      }
+    }
+  }
+  throw new Error('No Auth0 token found in e2e/.auth/user.json — run: node e2e/save-token.mjs');
+}
+
+async function withAuthInterceptor(page: import('@playwright/test').Page): Promise<void> {
+  const token = getBearerToken();
+  // Intercept every request to /graphql and forward directly to the UAT API from Node.js.
+  // This solves two problems:
+  // 1. Auth: injects Authorization on every request, including the first one that fires
+  //    before the Auth0 SDK has initialized and found the cached token.
+  // 2. CORS: the UAT API rejects requests with Origin: http://localhost:4200. By making
+  //    the request from Node.js (server-side) and stripping Origin + CORS fetch headers,
+  //    the API treats it as a same-origin call and accepts it.
+  await page.route('**/graphql', async route => {
+    try {
+      const { origin, 'sec-fetch-site': _a, 'sec-fetch-mode': _b, 'sec-fetch-dest': _c, ...safeHeaders } = route.request().headers();
+      const response = await route.fetch({
+        url: 'https://api-testing.communitytechaid.org.uk/graphql',
+        headers: {
+          ...safeHeaders,
+          'Authorization': `Bearer ${token}`,
+          'host': 'api-testing.communitytechaid.org.uk',
+        },
+      });
+      await route.fulfill({ response });
+    } catch {
+      // Context may have closed while an in-flight background GraphQL request was pending.
+    }
+  });
+}
+
+test.describe('Audit "Who" column — System label for automated revisions', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('dialog', dialog => dialog.dismiss().catch(() => {}));
+  });
+
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('shows System in Who column when customUser is "|"', async ({ page }) => {
+    // Step 1: navigate to devices list and grab the first kit detail link.
+    await withAuthInterceptor(page);
+    await page.goto('/dashboard/devices');
+
+    const linkLocator = page.locator('table tbody tr td a[href*="/dashboard/"]');
+    const appeared = await linkLocator.first().waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!appeared) {
+      test.skip(true, 'No devices in UAT');
+      return;
+    }
+
+    const href = await linkLocator.first().getAttribute('href');
+
+    // Step 2: register a MORE-SPECIFIC stub handler for the getAuditTrail query AFTER the
+    // auth interceptor (Playwright runs the most-recently-added matching handler first).
+    // If the POST body contains "getAuditTrail" or "kitAudits", fulfill with a canned
+    // response containing one audit whose revision.customUser is "|".  Otherwise fall back
+    // to the auth interceptor to proxy the request to UAT.
+    await page.route('**/graphql', async route => {
+      const postData = route.request().postData() ?? '';
+      if (postData.includes('getAuditTrail') || postData.includes('kitAudits')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              kitAudits: [
+                {
+                  revision: {
+                    id: 999,
+                    timestamp: '2024-01-01T00:00:00Z',
+                    customUser: '|',
+                  },
+                  type: 'MOD',
+                  entity: {
+                    model: 'Test Model',
+                    status: 'DONATED',
+                    serialNo: 'SN-TEST-001',
+                    updatedAt: '2024-01-01T00:00:00Z',
+                    createdAt: '2024-01-01T00:00:00Z',
+                    subStatus: {
+                      installationOfOSFailed: false,
+                      wipeFailed: false,
+                      needsSparePart: false,
+                      needsFurtherInvestigation: false,
+                      network: false,
+                      installedOSName: null,
+                      lockedToUser: false,
+                    },
+                  },
+                },
+              ],
+            },
+          }),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    // Step 3: navigate to the kit detail page.
+    await page.goto(href!);
+    await expect(page.locator('[ngbNav], ul.nav-tabs')).toBeVisible({ timeout: 15_000 });
+
+    // Step 4: click the Audit tab.
+    const auditTab = page.locator('ul.nav-tabs .nav-link', { hasText: /Audit/i });
+    await auditTab.click();
+    await expect(auditTab).toHaveClass(/active/, { timeout: 5_000 });
+
+    // Step 5: wait for the audit table to appear.
+    const auditTable = page.locator('table[id*="kit-audit-"]');
+    await expect(auditTable).toBeVisible({ timeout: 10_000 });
+
+    // Step 6: assert the Who cell (3rd column) of the first audit row shows "System".
+    // Columns: Revision #, When, Who, Model, Status, ...
+    const whoCell = auditTable.locator('tbody tr:first-child td:nth-child(3)');
+    await expect(whoCell).toHaveText('System', { timeout: 10_000 });
+  });
+});

--- a/src/app/views/corewidgets/components/device-request-audit-component/device-request-audit-component.html
+++ b/src/app/views/corewidgets/components/device-request-audit-component/device-request-audit-component.html
@@ -41,7 +41,7 @@
                     <tr>
                       <td> <span class="badge badge-secondary"> {{dt.revision.id}} </span> </td>
                       <td>{{ dt.revision.timestamp | date:'medium' }}</td>
-                      <td>{{ dt.revision.customUser?.split("|")[1] }}</td>
+                      <td>{{ dt.revision.customUser?.split("|")[1] || 'System' }}</td>
                       <td>{{ statusTypes[dt.entity.status] || dt.entity.status }}</td>
                       <td>{{ dt.entity.clientRef }}</td>
                       <td>{{ dt.entity.borough }}</td>

--- a/src/app/views/corewidgets/components/kit-audit-component/kit-audit-component.html
+++ b/src/app/views/corewidgets/components/kit-audit-component/kit-audit-component.html
@@ -41,7 +41,7 @@
                     <tr>
                       <td> <span class="badge badge-secondary"> {{dt.revision.id}} </span> </td>
                       <td>{{ dt.revision.timestamp | date:'medium' }}</td>
-                      <td>{{ dt.revision.customUser?.split("|")[1] }}</td>
+                      <td>{{ dt.revision.customUser?.split("|")[1] || 'System' }}</td>
                       <!-- <td>{{ dt.type }} </td> -->
                       <td>{{ dt.entity.model }}</td>
                       <!-- <td>{{ dt.entity.updatedAt | date:'medium' }}</td>


### PR DESCRIPTION
Fixes #56

## What
Audit revision records made by automated hardware-info processes showed **blank** in the "Who" column. Now they show **System**.

## Root cause
For automated revisions the backend stores `customUser` as `"|"`. The template renders `customUser?.split("|")[1]`, which extracts the empty string after the pipe → a blank cell. Adding a `|| 'System'` fallback labels these clearly.

- Normal user `"ROLE|jdoe"` → `jdoe` (truthy, unchanged)
- Automated `"|"` → `''` (falsy) → **System**
- `null` `customUser` → `undefined` → **System**

## Changes (display-only — no TS/GraphQL/backend change)
- `src/app/views/corewidgets/components/kit-audit-component/kit-audit-component.html` (line 44)
- `src/app/views/corewidgets/components/device-request-audit-component/device-request-audit-component.html` (line 44)
- `e2e/tests/audit-system-label.spec.ts` (new) — red/green regression spec.

## Test plan
- `ng build --configuration production` — passes clean (only pre-existing tsconfig warnings).
- New spec `e2e/tests/audit-system-label.spec.ts`: reaches a kit detail page, **stubs the `getAuditTrail` GraphQL response** with a revision whose `customUser` is `"|"` (so the System path is deterministic regardless of UAT data — other `/graphql` calls fall through to the UAT proxy), opens the Audit tab, and asserts the Who cell (`td:nth-child(3)`) renders `System`. Red-before / green-after by design.
- ⚠️ The spec needs a **UAT-enabled environment** to reach the detail page — the automation sandbox blocks `api-testing.communitytechaid.org.uk`, so it couldn't be executed here. Build is the authoritative local gate; please run the spec in a UAT-enabled env before relying on it.

## Note
The issue's watch-out — confirm the raw value is exactly `"|"` (not `"system|…"`) — couldn't be verified against UAT from the sandbox (host blocked). The fallback is robust regardless: it triggers on any empty/null user portion, so it correctly labels both `"|"` and a fully-null `customUser` as System without affecting real usernames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUkw3j8oq2J8nv7XQSriZz)_