### PR TITLE
feat: add notes section to referee details (#65)

### DIFF
--- a/e2e/tests/referee-notes.spec.ts
+++ b/e2e/tests/referee-notes.spec.ts
@@ -1,0 +1,81 @@
+// Requires a UAT-enabled environment to reach the referee detail page.
+// The sandbox host allowlist blocks api-testing.communitytechaid.org.uk so it can't run here.
+
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function getBearerToken(): string {
+  const statePath = resolve(process.cwd(), 'e2e/.auth/user.json');
+  const state = JSON.parse(readFileSync(statePath, 'utf8'));
+  for (const origin of state.origins ?? []) {
+    for (const item of origin.localStorage ?? []) {
+      if (item.name.startsWith('@@auth0spajs@@')) {
+        const parsed = JSON.parse(item.value);
+        return parsed?.body?.access_token ?? '';
+      }
+    }
+  }
+  throw new Error('No Auth0 token found in e2e/.auth/user.json — run: node e2e/save-token.mjs');
+}
+
+async function withAuthInterceptor(page: import('@playwright/test').Page): Promise<void> {
+  const token = getBearerToken();
+  await page.route('**/graphql', async route => {
+    try {
+      const { origin, 'sec-fetch-site': _a, 'sec-fetch-mode': _b, 'sec-fetch-dest': _c, ...safeHeaders } = route.request().headers();
+      const response = await route.fetch({
+        url: 'https://api-testing.communitytechaid.org.uk/graphql',
+        headers: {
+          ...safeHeaders,
+          'Authorization': `Bearer ${token}`,
+          'host': 'api-testing.communitytechaid.org.uk',
+        },
+      });
+      await route.fulfill({ response });
+    } catch {
+      // Context may have closed while an in-flight background GraphQL request was pending.
+    }
+  });
+}
+
+test.describe('Referee notes UI', () => {
+  test.afterEach(async ({ page }) => {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('referee detail page shows notes UI', async ({ page }) => {
+    page.on('dialog', dialog => dialog.dismiss().catch(() => {}));
+
+    await withAuthInterceptor(page);
+    await page.goto('/dashboard/referring-organisation-contacts');
+
+    // Wait for the table to load and find the first detail link
+    const linkLocator = page.locator('table tbody tr td a[href*="/dashboard/"]');
+    const appeared = await linkLocator.first().waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!appeared) {
+      test.skip(true, 'No referees in UAT');
+      return;
+    }
+
+    const href = await linkLocator.first().getAttribute('href');
+    await withAuthInterceptor(page);
+    await page.goto(href);
+
+    // Ensure the Details tab is active (it is by default on load)
+    await expect(page.locator('ul.nav-tabs .nav-link').first()).toHaveClass(/active/, { timeout: 15_000 });
+
+    // Assert notes UI is present: new-note textarea label
+    await expect(
+      page.locator('label', { hasText: 'Add a new note for this referee' })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Assert the notes list container is present
+    await expect(
+      page.locator('.notes-list')
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/src/app/views/corewidgets/components/referring-organisation-contact-info/custom-create-notes.ts
+++ b/src/app/views/corewidgets/components/referring-organisation-contact-info/custom-create-notes.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { ToastrService } from 'ngx-toastr';
+import gql from 'graphql-tag';
+import { Apollo } from 'apollo-angular';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+    selector: 'formly-field-create-referring-organisation-contact-note',
+    template: `
+  <div class="note-new" style="margin-bottom:20px">
+    <label>Add a new note for this referee</label>
+    <textarea class="form-control" #newNoteContent rows="4" [name]=key [formControl]="formControl" [placeholder]=to.placeholder (keyup.enter)="$event.stopPropagation()"></textarea>
+  </div>
+ `,
+    imports: [ReactiveFormsModule]
+})
+export class FormlyCustomCreateReferringOrganisationContactNote extends FieldType  {
+}

--- a/src/app/views/corewidgets/components/referring-organisation-contact-info/custom-notes.ts
+++ b/src/app/views/corewidgets/components/referring-organisation-contact-info/custom-notes.ts
@@ -1,0 +1,74 @@
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+import { ToastrService } from 'ngx-toastr';
+import gql from 'graphql-tag';
+import { Apollo } from 'apollo-angular';
+import { DatePipe } from '@angular/common';
+
+const DELETE_NOTE = gql`
+mutation deleteReferringOrganisationContactNote($id: ID!) {
+  deleteReferringOrganisationContactNote(id: $id)
+}
+`;
+
+@Component({
+    selector: 'formly-field-referring-organisation-contact-notes',
+    template: `
+<div class="notes-list" style="max-height:350px; overflow-y:scroll">
+  @for (note of to.notes; track note) {
+    <div class="note-item ">
+      <div style="border: solid 3px #e3e6f0" class="card">
+        <div class="card-body" style="padding:10px">
+          <span>{{ note.content }}</span>
+          <div class="d-flex row justify-content-between">
+            <div class="d-flex col-9 flex-row align-items-center">
+              <span style="max-width:60%" class="small text-muted text-truncate  mb-0 ms-2" title="{{ note.volunteer }}"><em>{{ note.volunteer }}</em></span>
+              <span class="small text-muted mb-0"><em>&nbsp;({{ note.updated_at | date : "dd/MM/yy HH:mm" }})</em></span>
+            </div>
+            <div class="d-flex col-2 flex-row">
+              <button (click)="deleteReferringOrganisationContactNote(note.id)" class="btn rounded-0" type="button" title="Delete"><i style="color: #c51616" class="fas fa-window-close fa-lg"></i></button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  }
+</div>
+`,
+    imports: [DatePipe]
+})
+export class FormlyCustomReferringOrganisationContactNote extends FieldType {
+
+
+    constructor(
+        private toastr: ToastrService,
+        private apollo: Apollo
+    ) {
+        super();
+    }
+
+    /* Delete note calls the delete mutation directly and reloads the page to refresh the listings. There might be a way to prevent reload but it's too complicated. Also KISS/YAGNI
+     */
+    deleteReferringOrganisationContactNote(id: any) {
+        if(!confirm('Are you sure you want to delete this entry?')){
+            return
+        }
+        this.apollo.mutate<any>({
+            mutation: DELETE_NOTE,
+            variables: { id: id }
+        }).subscribe(res => {
+            this.toastr.info(`
+          <small>Successfully deleted note</small>
+          `, 'Deleted Note', {
+                enableHtml: true
+            });
+            location.reload();
+        }, err => {
+            this.toastr.error(`
+          <small>${err.message}</small>
+          `, 'Error Deleting Note', {
+                enableHtml: true
+            });
+        });
+    }
+}

--- a/src/app/views/corewidgets/components/referring-organisation-contact-info/referring-organisation-contact-info.component.ts
+++ b/src/app/views/corewidgets/components/referring-organisation-contact-info/referring-organisation-contact-info.component.ts
@@ -29,6 +29,13 @@ const QUERY_ENTITY = gql`
         id
         name
       }
+      notes {
+        id
+        content
+        volunteer
+        createdAt
+        updatedAt
+      }
     }
   }
 `;
@@ -45,6 +52,13 @@ const UPDATE_ENTITY = gql`
       referringOrganisation {
         id
         name
+      }
+      notes {
+        id
+        content
+        volunteer
+        createdAt
+        updatedAt
       }
     }
   }
@@ -102,6 +116,21 @@ export class ReferringOrganisationContactInfoComponent {
   referringOrganisationId: number;
   public user: User;
   @Select(UserState.user) user$: Observable<User>;
+
+  newNoteField: FormlyFieldConfig = {
+    key: 'note.content',
+    type: 'referee-new-note',
+    templateOptions: {
+      placeholder: "Type your note here and hit save"
+    }
+  }
+
+  notesField: FormlyFieldConfig = {
+    type: 'referee-notes',
+    templateOptions: {
+      notes: [],
+    },
+  }
 
   referringOrganisations$: Observable<any>;
   referringOrganisationInput$ = new Subject<string>();
@@ -232,6 +261,13 @@ export class ReferringOrganisationContactInfoComponent {
         }
       ],
     },
+    {
+      fieldGroupClassName: 'row',
+      fieldGroup: [
+        { className: 'col-md-6', fieldGroup: [this.newNoteField] },
+        { className: 'col-md-6', fieldGroup: [this.notesField] },
+      ],
+    },
   ];
 
 
@@ -245,7 +281,10 @@ export class ReferringOrganisationContactInfoComponent {
   }
 
   private normalizeData(data: any) {
-    data = { ...data }; // Apollo v3 freezes query results in dev mode; copy before mutating
+    data = structuredClone(data); // Apollo v4 deep-freezes query/mutation responses; deep-clone before Formly writes to nested objects
+
+    this.newNoteField.templateOptions['refereeId'] = this.refereeId;
+    this.displayNotes(data);
 
     if (data.referringOrganisation && data.referringOrganisation.id) {
       data.referringOrganisationId = data.referringOrganisation.id;
@@ -254,6 +293,16 @@ export class ReferringOrganisationContactInfoComponent {
       ];
     }
     return data;
+  }
+
+  private displayNotes(data) {
+    if (data.notes) {
+      var notes = [];
+      data.notes.forEach(n => {
+        notes.push({ content: n.content, id: n.id, volunteer: n.volunteer, updated_at: n.updatedAt });
+      });
+      this.notesField.templateOptions['notes'] = notes;
+    }
   }
 
   private fetchData() {
@@ -361,6 +410,10 @@ export class ReferringOrganisationContactInfoComponent {
       return;
     }
     data.id = this.refereeId;
+
+    if (data.note && data.note.content == null) {
+      data.note.content = "";
+    }
 
     this.apollo
       .mutate({

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,8 @@ import { FormlyCustomNote } from './app/views/corewidgets/components/kit-info/cu
 import { FormlyCustomCreateNote } from './app/views/corewidgets/components/kit-info/custom-create-note';
 import { FormlyCustomDeviceRequestNote } from './app/views/corewidgets/components/device-request-info/custom-notes';
 import { FormlyCustomCreateDeviceRequestNote } from './app/views/corewidgets/components/device-request-info/custom-create-notes';
+import { FormlyCustomReferringOrganisationContactNote } from './app/views/corewidgets/components/referring-organisation-contact-info/custom-notes';
+import { FormlyCustomCreateReferringOrganisationContactNote } from './app/views/corewidgets/components/referring-organisation-contact-info/custom-create-notes';
 import { FormlyCustomKitCheckboxType } from './app/views/corewidgets/components/kit-info/custom-kit-checkbox';
 import { FormlyCustomKitInfoType } from './app/views/corewidgets/components/kit-info/custom-kit-info-input';
 
@@ -50,6 +52,8 @@ bootstrapApplication(AppComponent, {
         { name: 'new-note', component: FormlyCustomCreateNote },
         { name: 'device-request-notes', component: FormlyCustomDeviceRequestNote },
         { name: 'device-request-new-note', component: FormlyCustomCreateDeviceRequestNote },
+        { name: 'referee-notes', component: FormlyCustomReferringOrganisationContactNote },
+        { name: 'referee-new-note', component: FormlyCustomCreateReferringOrganisationContactNote },
         { name: 'kit-checkbox', component: FormlyCustomKitCheckboxType },
         { name: 'kit-info-input', component: FormlyCustomKitInfoType },
       ]


### PR DESCRIPTION
Fixes #65

## What
Adds a freeform **notes/context section** to the Referee (ReferringOrganisationContact) detail page, so users can capture extra context (team/department, consent, etc.) in one place. Mirrors the existing notes feature on Kit and DeviceRequest.

## Unblocked by backend
This was previously blocked on backend support. The backend now exposes the contract this PR consumes:
- `ReferringOrganisationContact.notes { id content volunteer createdAt updatedAt }`
- `note` input (`ReferringOrganisationContactNoteInput { content }`) on `UpdateReferringOrganisationContactInput`
- `deleteReferringOrganisationContactNote(id: ID!): Boolean`

## Approach
Cloned the `device-request-info` notes implementation, renamed for the referee entity — no new patterns invented.

## Changes
- **New** `referring-organisation-contact-info/custom-notes.ts` — notes list + delete (via `deleteReferringOrganisationContactNote`).
- **New** `referring-organisation-contact-info/custom-create-notes.ts` — "Add a new note for this referee" textarea.
- `src/main.ts` — registers formly types `referee-notes` / `referee-new-note`.
- `referring-organisation-contact-info.component.ts`:
  - `notes { … }` added to `QUERY_ENTITY` and `UPDATE_ENTITY`.
  - `newNoteField` (`key: 'note.content'`) + `notesField`, rendered as a new row in the Details-tab form.
  - `displayNotes()` maps `data.notes` for display; `normalizeData()` switched to `structuredClone` (matching device-request) so nested note objects aren't frozen.
- **New** `e2e/tests/referee-notes.spec.ts` — red/green regression spec.

## Test plan
- `ng build --configuration production` — passes clean (only pre-existing tsconfig warnings).
- `e2e/tests/referee-notes.spec.ts`: opens a referee detail page and asserts the "Add a new note for this referee" textarea and notes panel render. Red-before / green-after (the referee page had no notes UI before). Non-destructive — it does not create/delete notes against UAT.
- ⚠️ The spec requires a **UAT-enabled environment** to reach the detail page — the automation sandbox blocks `api-testing.communitytechaid.org.uk`, so it couldn't be run here. Build is the authoritative local gate; please run the spec (and ideally a manual create/delete round-trip) in a UAT-enabled env before merge.

## Scope
Referee component only — kit-info / device-request-info untouched. Contact-level notes (not the parent organisation), per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PUkw3j8oq2J8nv7XQSriZz)_